### PR TITLE
Add support for Waveshare ESP32-S3 with 1.28-inch touch display

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -23,18 +23,48 @@ constexpr unsigned long kWifiDownGraceMs = 4000;
 /** Minimum interval between background reconnect tries. */
 constexpr unsigned long kWifiReconnectIntervalMs = 15000;
 
-// --- BOOT button (ESP32-C3 Super Mini, active LOW) ---
-constexpr gpio_num_t kBootPin = GPIO_NUM_9;
-constexpr unsigned long kBootResetHoldMs = 3000UL;
-/** Ignore BOOT taps shorter than this (debounce). */
-constexpr unsigned long kBootTapMinMs = 40UL;
+// --- Board pin profiles (selected via -DBOARD_* in platformio.ini) ---
+// Both boards drive a GC9A01(A) 1.28" round 240×240 panel over SPI.
+#if defined(BOARD_S3_WAVESHARE_TOUCH128)
 
-// --- Display: GC9A01 1.28" round 240×240 (SPI) ---
+// Waveshare ESP32-S3-Touch-LCD-1.28 (ESP32-S3R2)
+constexpr gpio_num_t kBootPin = GPIO_NUM_0;  // BOOT0 button, active LOW
+constexpr gpio_num_t kDisplayPinRst = GPIO_NUM_14;
+constexpr gpio_num_t kDisplayPinCs = GPIO_NUM_9;
+constexpr gpio_num_t kDisplayPinDc = GPIO_NUM_8;
+constexpr gpio_num_t kDisplayPinMosi = GPIO_NUM_11;  // display SDA
+constexpr gpio_num_t kDisplayPinSclk = GPIO_NUM_10;  // display SCL
+constexpr gpio_num_t kDisplayPinBl = GPIO_NUM_2;     // backlight (active HIGH)
+#define DISPLAY_HAS_BACKLIGHT 1
+
+// CST816S capacitive touch (I2C). A tap cycles the range preset (no BOOT button).
+constexpr gpio_num_t kTouchPinSda = GPIO_NUM_6;
+constexpr gpio_num_t kTouchPinScl = GPIO_NUM_7;
+constexpr gpio_num_t kTouchPinInt = GPIO_NUM_5;
+constexpr gpio_num_t kTouchPinRst = GPIO_NUM_13;
+constexpr uint8_t kTouchI2cAddr = 0x15;
+/** Debounce: ignore a repeat tap within this window of the last one. */
+constexpr unsigned long kTouchTapDebounceMs = 250UL;
+#define DISPLAY_HAS_TOUCH 1
+
+#else  // BOARD_C3_SUPERMINI (default)
+
+// ESP32-C3 Super Mini
+constexpr gpio_num_t kBootPin = GPIO_NUM_9;  // BOOT button, active LOW
 constexpr gpio_num_t kDisplayPinRst = GPIO_NUM_0;
 constexpr gpio_num_t kDisplayPinCs = GPIO_NUM_1;
 constexpr gpio_num_t kDisplayPinDc = GPIO_NUM_10;
 constexpr gpio_num_t kDisplayPinMosi = GPIO_NUM_3;  // display SDA
 constexpr gpio_num_t kDisplayPinSclk = GPIO_NUM_4;  // display SCL
+constexpr gpio_num_t kDisplayPinBl = GPIO_NUM_NC;   // backlight tied to power (no GPIO)
+
+#endif
+
+constexpr unsigned long kBootResetHoldMs = 3000UL;
+/** Ignore BOOT taps shorter than this (debounce). */
+constexpr unsigned long kBootTapMinMs = 40UL;
+
+// --- Display: GC9A01 1.28" round 240×240 (SPI) ---
 
 constexpr int kDisplayWidth = 240;
 constexpr int kDisplayHeight = 240;

--- a/include/hardware/lgfx_config.hpp
+++ b/include/hardware/lgfx_config.hpp
@@ -9,6 +9,9 @@
 class LGFX : public lgfx::LGFX_Device {
   lgfx::Bus_SPI _bus;
   lgfx::Panel_GC9A01 _panel;
+#ifdef DISPLAY_HAS_BACKLIGHT
+  lgfx::Light_PWM _light;
+#endif
 
 public:
   LGFX() {
@@ -31,6 +34,17 @@ public:
       cfg.rgb_order = config::kDisplayRgbOrder;
       _panel.config(cfg);
     }
+#ifdef DISPLAY_HAS_BACKLIGHT
+    {
+      auto cfg = _light.config();
+      cfg.pin_bl = static_cast<int>(config::kDisplayPinBl);
+      cfg.invert = false;  // active HIGH
+      cfg.freq = 12000;
+      cfg.pwm_channel = 7;
+      _light.config(cfg);
+      _panel.setLight(&_light);  // enables tft.setBrightness()
+    }
+#endif
     setPanel(&_panel);
   }
 };

--- a/include/hardware/touch.h
+++ b/include/hardware/touch.h
@@ -1,0 +1,17 @@
+#pragma once
+
+/**
+ * CST816S capacitive touch (Waveshare ESP32-S3-Touch-LCD-1.28 only).
+ *
+ * On boards without a touch panel (e.g. ESP32-C3 Super Mini) both functions
+ * compile to no-ops, so callers need no #ifdefs.
+ */
+
+/** Init I2C + reset the controller. Safe to call once in setup(). */
+void touchInit();
+
+/**
+ * Poll the panel; returns true once per finger-down (a "tap"). A held finger
+ * does not repeat — the next tap needs a lift first.
+ */
+bool touchConsumeTap();

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,9 +1,12 @@
-; ESP32-C3 Super Mini + 1.28" round GC9A01 (240×240)
-; Board in Arduino IDE: "ESP32C3 Dev Module" or "MakerGO ESP32 C3 SuperMini"
+; Plane Radar — 1.28" round GC9A01 (240×240) on SPI
+; Two build targets share the same firmware; each board has its own pinout
+; (selected by the BOARD_* flag below; pins live in include/config.h):
+;   env:supermini          — ESP32-C3 Super Mini ("ESP32C3 Dev Module" / "MakerGO ESP32 C3 SuperMini")
+;   env:waveshare-s3-touch — Waveshare ESP32-S3-Touch-LCD-1.28 (GC9A01A + CST816S, 16MB flash, 2MB PSRAM)
+; Build a specific target with:  pio run -e supermini   |   pio run -e waveshare-s3-touch
 
-[env:supermini]
+[env]
 platform = espressif32@6.5.0
-board = esp32-c3-devkitm-1
 framework = arduino
 monitor_speed = 115200
 extra_scripts = post:scripts/merge_firmware.py
@@ -11,7 +14,7 @@ extra_scripts = post:scripts/merge_firmware.py
 ; Anti-aliased VLW font (Noto Sans Bold 15, from TFT_eSPI smooth-font examples)
 board_build.embed_files = data/ui_font.vlw
 
-; USB serial over USB-C (Super Mini native USB)
+; USB serial over native USB (Super Mini / DevKitC-1 native USB)
 build_flags =
   -DARDUINO_USB_MODE=1
   -DARDUINO_USB_CDC_ON_BOOT=1
@@ -22,3 +25,17 @@ lib_deps =
   lovyan03/LovyanGFX@^1.2.7
   tzapu/WiFiManager@^2.0.17
   bblanchon/ArduinoJson@^7.4.2
+
+[env:supermini]
+board = esp32-c3-devkitm-1
+build_flags =
+  ${env.build_flags}
+  -DBOARD_C3_SUPERMINI
+
+[env:waveshare-s3-touch]
+board = esp32-s3-devkitc-1
+board_build.flash_size = 16MB
+board_upload.flash_size = 16MB
+build_flags =
+  ${env.build_flags}
+  -DBOARD_S3_WAVESHARE_TOUCH128

--- a/src/hardware/touch.cpp
+++ b/src/hardware/touch.cpp
@@ -1,0 +1,79 @@
+#include "hardware/touch.h"
+
+#include "config.h"
+
+#ifdef DISPLAY_HAS_TOUCH
+
+#include <Arduino.h>
+#include <Wire.h>
+
+namespace {
+
+// INT pulses LOW on a touch event. We poll the finger-count register over I2C
+// each call; the ISR flag only catches a quick tap that started AND ended while
+// a blocking section (e.g. an HTTP fetch) kept us from polling.
+volatile bool s_int_fired = false;
+bool s_finger_down = false;
+unsigned long s_last_tap_ms = 0;
+
+void IRAM_ATTR onTouchIsr() { s_int_fired = true; }
+
+/** Read one CST816S register; returns 0 on any I2C error. */
+uint8_t readReg(uint8_t reg) {
+  Wire.beginTransmission(config::kTouchI2cAddr);
+  Wire.write(reg);
+  if (Wire.endTransmission(true) != 0) {
+    return 0;
+  }
+  if (Wire.requestFrom(static_cast<int>(config::kTouchI2cAddr), 1) != 1) {
+    return 0;
+  }
+  return Wire.read();
+}
+
+}  // namespace
+
+void touchInit() {
+  // Hardware reset: low pulse, then let the controller boot.
+  pinMode(config::kTouchPinRst, OUTPUT);
+  digitalWrite(config::kTouchPinRst, LOW);
+  delay(10);
+  digitalWrite(config::kTouchPinRst, HIGH);
+  delay(60);
+
+  Wire.begin(static_cast<int>(config::kTouchPinSda),
+             static_cast<int>(config::kTouchPinScl), 400000);
+
+  pinMode(config::kTouchPinInt, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(static_cast<uint8_t>(config::kTouchPinInt)),
+                  onTouchIsr, FALLING);
+}
+
+bool touchConsumeTap() {
+  const bool down = readReg(0x02) > 0;  // CST816S reg 0x02 = finger count (0/1)
+  const bool press_edge = down && !s_finger_down;
+
+  // A tap that began and ended between polls: INT fired but finger is up again.
+  const bool missed = s_int_fired && !down && !s_finger_down;
+  s_int_fired = false;
+  s_finger_down = down;
+
+  // Only the down-edge fires, so holding a finger never repeats; the timer
+  // just rejects contact bounce that would double-count one tap.
+  if (!press_edge && !missed) {
+    return false;
+  }
+  const unsigned long now = millis();
+  if (now - s_last_tap_ms < config::kTouchTapDebounceMs) {
+    return false;
+  }
+  s_last_tap_ms = now;
+  return true;
+}
+
+#else  // no touch panel on this board
+
+void touchInit() {}
+bool touchConsumeTap() { return false; }
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 
 #include "config.h"
 #include "hardware/display.h"
+#include "hardware/touch.h"
 #include "services/adsb_client.h"
 #include "services/radar_location.h"
 #include "services/wifi_setup.h"
@@ -42,9 +43,9 @@ void onRangeTap() {
   }
 }
 
-void handleBootButton() {
+void handleInput() {
   bootButtonPollLongPress();
-  if (bootButtonConsumeTap()) {
+  if (bootButtonConsumeTap() || touchConsumeTap()) {
     onRangeTap();
   }
 }
@@ -53,11 +54,11 @@ void fetchAndDrawAircraft() {
   const float fetch_km = ui::radar::fetchRadiusKm();
   if (!services::adsb::fetchUpdate(services::location::lat(),
                                    services::location::lon(), fetch_km)) {
-    handleBootButton();
+    handleInput();
     return;
   }
   ui::radarDisplayRefreshAircraft();
-  handleBootButton();
+  handleInput();
 }
 
 }  // namespace
@@ -69,6 +70,7 @@ void setup() {
   Serial.println("Plane Radar");
 
   bootButtonInit();
+  touchInit();
   displayInit();
   if (wifiShowsSetupScreenOnBoot()) {
     statusScreenPortal();
@@ -82,7 +84,7 @@ void setup() {
 }
 
 void loop() {
-  handleBootButton();
+  handleInput();
 
   if (WiFi.status() != WL_CONNECTED) {
     if (g_radar_visible) {


### PR DESCRIPTION
This PR adds the `waveshare-s3-touch` environment for the Waveshare ESP32-S3 device with 1.28" touch display. It wires up the zoom cycling to screen touches, since the BOOT button is not accessible. It also has a backlight which needs controlling.

- buy it: https://www.amazon.com/dp/B0CZ6W4YBX
- documentation: https://docs.waveshare.com/ESP32-S3-Touch-LCD-1.28

<img width="4032" height="3024" alt="IMG_1264" src="https://github.com/user-attachments/assets/e7e811e6-ffb5-42d4-a50a-07adf970ea0b" />
