### PR TITLE
Added support Seeed Studio XIAO Round Display with ESP32-C3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 
 <img width="800" height="450" alt="plane-radar" src="https://github.com/user-attachments/assets/716d0992-dab8-47ba-8f1a-2aec7f607419" />
 
-**3D printed case (STL + assembly):** [MakerWorld](https://makerworld.com/en/models/2872376-esp32-plane-radar-live-ads-b-on-a-round-display#profileId-3207083) · **Firmware:** [Releases](https://github.com/MatixYo/ESP32-Plane-Radar/releases)
+Firmware for an **ESP32-C3** and a **1.28″ round display** (240×240px). Shows a circular **ADS-B radar** around your configured location, with **WiFiManager** for first-time setup.
 
-Firmware for an **ESP32-C3 Super Mini** and a **1.28″ round GC9A01** display (240×240). Shows a circular **ADS-B radar** around your configured location, with **WiFiManager** for first-time setup.
+**Firmware:** [Releases](https://github.com/MatixYo/ESP32-Plane-Radar/releases)
+
+## Supported Hardware
+
+1. ESP32-C3 Super Mini with 1.28" round GC9A01 display
+   1. **3D printed case (STL + assembly):** [MakerWorld](https://makerworld.com/en/models/2872376-esp32-plane-radar-live-ads-b-on-a-round-display#profileId-3207083)
+2. Seeed Studio XIAO Round Display with XIAO ESP32-C3
+   1. Off the shelf plug-and-play solution with several 3d case designs
 
 ## What it does
 

--- a/include/config.h
+++ b/include/config.h
@@ -29,12 +29,23 @@ constexpr unsigned long kBootResetHoldMs = 3000UL;
 /** Ignore BOOT taps shorter than this (debounce). */
 constexpr unsigned long kBootTapMinMs = 40UL;
 
+#if defined(DISPLAY_TARGET_SUPERMINI)
 // --- Display: GC9A01 1.28" round 240×240 (SPI) ---
+#pragma message("Using configuration for DISPLAY_TARGET_SUPERMINI")
 constexpr gpio_num_t kDisplayPinRst = GPIO_NUM_0;
 constexpr gpio_num_t kDisplayPinCs = GPIO_NUM_1;
 constexpr gpio_num_t kDisplayPinDc = GPIO_NUM_10;
 constexpr gpio_num_t kDisplayPinMosi = GPIO_NUM_3;  // display SDA
 constexpr gpio_num_t kDisplayPinSclk = GPIO_NUM_4;  // display SCL
+#elif defined(DISPLAY_TARGET_SEEED_XIAO)
+// --- Display: 1.28" round 240×240 XIAO Round Display from SeeedStudio ---
+#pragma message("Using configuration for DISPLAY_TARGET_SEEED_XIAO")
+constexpr gpio_num_t kDisplayPinRst = GPIO_NUM_NC;   // not exposed on xiao round display
+constexpr gpio_num_t kDisplayPinCs  = GPIO_NUM_3;    // D1/GPIO 3
+constexpr gpio_num_t kDisplayPinDc  = GPIO_NUM_5;    // D3/GPIO 5
+constexpr gpio_num_t kDisplayPinMosi = GPIO_NUM_10;  // XIAO SPI MOSI
+constexpr gpio_num_t kDisplayPinSclk = GPIO_NUM_8;   // XIAO SPI SCK
+#endif
 
 constexpr int kDisplayWidth = 240;
 constexpr int kDisplayHeight = 240;

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,9 +1,6 @@
-; ESP32-C3 Super Mini + 1.28" round GC9A01 (240×240)
-; Board in Arduino IDE: "ESP32C3 Dev Module" or "MakerGO ESP32 C3 SuperMini"
-
-[env:supermini]
+; Base environment
+[env:base]
 platform = espressif32@6.5.0
-board = esp32-c3-devkitm-1
 framework = arduino
 monitor_speed = 115200
 extra_scripts = post:scripts/merge_firmware.py
@@ -22,3 +19,31 @@ lib_deps =
   lovyan03/LovyanGFX@^1.2.7
   tzapu/WiFiManager@^2.0.17
   bblanchon/ArduinoJson@^7.4.2
+
+
+; ============================================================
+; ESP32-C3 Super Mini + 1.28" round GC9A01 (240×240)
+; Board in Arduino IDE: "ESP32C3 Dev Module" or "MakerGO ESP32 C3 SuperMini"
+; ============================================================
+
+[env:supermini]
+extends = env:base
+board = esp32-c3-devkitm-1
+
+build_flags =
+  ${env:base.build_flags}
+  -DDISPLAY_TARGET_SUPERMINI
+
+
+; ============================================================
+; Seeed Studio XIAO ESP32-C3
+; ============================================================
+
+[env:seeed_xiao]
+extends = env:base
+
+board = seeed_xiao_esp32c3
+
+build_flags =
+  ${env:base.build_flags}
+  -DDISPLAY_TARGET_SEEED_XIAO


### PR DESCRIPTION
[Seeed Studio XIAO Round Display](https://www.seeedstudio.com/1-28-Round-Touch-Display-for-Seeed-Studio-XIAO-ESP32.html) with [Xiao ESP32-C3](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C3-Pre-Soldered-p-6331.html) is a simple plug and play solution for those interested in making one.

I guess you'd receive a lot of PRs for different boards soon!. 
So, in this PR, I've extracted common app configuration into a base environment `[env:base]` so that all other supported boards extend from it. Each board's build step uses a board specific flag `DISPLAY_TARGET_...` that can be used to customize pin assignments or functionality. 