### PR TITLE
Add native unit tests and extract radar_math library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install PlatformIO
         run: pip install --upgrade platformio
 
+      - name: Run native tests
+        run: pio test -e native
+
       - name: Build
         run: pio run -e supermini
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Flash
+
+```bash
+# Build firmware
+pio run -e supermini
+
+# Build and flash to device
+pio run -t upload
+
+# Open serial monitor (115200 baud)
+pio device monitor
+
+# Build merged web-flash image (outputs .pio/build/supermini/firmware-merged.bin)
+pio run -e supermini
+pio run -t merge -e supermini
+
+# Build and produce release/plane-radar-merged.bin
+./scripts/merge-firmware.sh
+
+# Skip rebuild if firmware already built
+./scripts/merge-firmware.sh --no-build
+```
+
+There are no unit tests — this is embedded firmware; validation is done by flashing and observing the device.
+
+## Architecture
+
+The firmware follows a layered namespace structure:
+
+- **`config` namespace** (`include/config.h`) — compile-time constants for all hardware pins, timing, and behavior tuning. This is the single place to change hardware configuration.
+
+- **`hardware/` layer** — LovyanGFX display driver (`lgfx_config.hpp` defines the `LGFX` class for GC9A01 over SPI; `display.h`/`display.cpp` expose `displayInit()`). Note: `bootButtonInit()` and all BOOT button ISR/polling code live in `src/services/wifi_setup.cpp`, not in the hardware layer.
+
+- **`services/` layer** — network services with namespaces:
+  - `services::adsb` — fetches aircraft from `opendata.adsb.fi/api/v3/`; stores up to 64 `Aircraft` structs in a static buffer
+  - `services::location` — reads/writes radar center lat/lon from NVS (`planeradar` namespace)
+  - `wifi_setup` — wraps WiFiManager for captive portal setup
+
+- **`ui/` layer** — display rendering:
+  - `ui::radar` — range preset management; persists to NVS; `fetchRadiusKm()` scales fetch area to the screen edge
+  - `ui::radarDisplayDraw()` — draws the full sonar grid; caches it to a sprite for fast refresh
+  - `ui::radarDisplayRefreshAircraft()` — blits cached grid then redraws only aircraft (avoids full clear)
+  - `status_screens` — yellow/black status overlays (portal, connecting, etc.)
+
+- **`main.cpp`** — Arduino `setup()`/`loop()` wiring only; no logic beyond the state machine for WiFi recovery and ADS-B poll timing.
+
+### Key design points
+
+- The radar grid is rendered once into a sprite; aircraft refreshes blit the sprite then draw on top — this is why `radarDisplayRefreshAircraft()` is separate from `radarDisplayDraw()`.
+- Three NVS namespaces are used deliberately to avoid handle conflicts: `planeradar` (range preset index, miles/km preference), `radar` (lat/lon), and `wifi` (force-portal flag set before reboot on credential reset).
+- `ui::radar::fetchRadiusKm()` intentionally fetches beyond the visible outer ring so that aircraft just outside the ring still appear as rim dots.
+- WiFiManager custom parameters (lat, lon, units) are read back in `services::location::init()` and `ui::radar::rangeInit()` after the portal saves them.
+- Aircraft are drawn far-first (insertion sort by distance²) so nearer aircraft render on top of farther ones.
+- The GC9A01 panel uses BGR order (`kDisplayRgbOrder = true`). `initPalette()` in `radar_display.cpp` compensates by swapping R↔B when calling `color565()` for aircraft colors — changing any color needs to account for this swap.
+- `data/ui_font.vlw` is a pre-built binary (Noto Sans Bold 15, generated from TFT_eSPI smooth-font tooling). There is no script in this repo to regenerate it. The display code gracefully falls back to GFX bitmap fonts (`FreeSansBold12pt7b` / `FreeSansBold9pt7b`) if the VLW font fails to load.
+- The ADS-B HTTPS client uses `client.setInsecure()` — TLS is used for transport encryption but certificate verification is skipped.
+- The merged `.bin` (bootloader + partition table + firmware at correct offsets) is what users flash via esptool-js at address `0x0`.
+
+## CI & Releases
+
+- **Build workflow** triggers on push/PR to `main`; artifacts expire in ~90 days.
+- **Release workflow** triggers on `v*` tags; produces `plane-radar-vX.Y.Z.bin` as a GitHub Release asset.
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```

--- a/lib/radar_math/radar_math.h
+++ b/lib/radar_math/radar_math.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+// Pure, dependency-free math and parsing utilities.
+// No Arduino/ESP32/LovyanGFX headers — compiles on native host for testing.
+
+namespace radar_math {
+
+constexpr float kKmPerDeg = 111.0f;
+constexpr float kKmPerMile = 1.609344f;
+constexpr float kDegToRad = 0.01745329252f;
+
+// Aircraft position relative to radar center, in km.
+// Applies cos(lat) correction so east/west distances are accurate at non-equatorial latitudes.
+inline void offsetKm(double center_lat, double center_lon,
+                     float lat, float lon,
+                     float* dx_km, float* dy_km, float* dist_km) {
+  const float cos_lat = cosf(static_cast<float>(center_lat) * kDegToRad);
+  *dx_km = static_cast<float>(lon - center_lon) * kKmPerDeg * cos_lat;
+  *dy_km = static_cast<float>(lat - center_lat) * kKmPerDeg;
+  *dist_km = sqrtf((*dx_km) * (*dx_km) + (*dy_km) * (*dy_km));
+}
+
+// WiFiManager checkbox: submits value= attribute ("T") when checked, "" when unchecked.
+inline bool portalCheckboxChecked(const char* value) {
+  if (value == nullptr || value[0] == '\0') {
+    return false;
+  }
+  if (value[1] == '\0') {
+    return value[0] == 'T' || value[0] == 't';
+  }
+  return strcmp(value, "on") == 0;
+}
+
+inline bool validLatLon(double lat, double lon) {
+  return lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0;
+}
+
+inline bool parseCoord(const char* text, double* out) {
+  if (text == nullptr || text[0] == '\0') {
+    return false;
+  }
+  char* end = nullptr;
+  const double v = strtod(text, &end);
+  if (end == text || (end != nullptr && *end != '\0')) {
+    return false;
+  }
+  *out = v;
+  return true;
+}
+
+inline void formatRing3Label(char* buf, size_t len, float ring3_km, bool use_miles) {
+  if (use_miles) {
+    const int mi = static_cast<int>(lroundf(ring3_km / kKmPerMile));
+    snprintf(buf, len, "%dmi", mi);
+  } else {
+    const int km = static_cast<int>(lroundf(ring3_km));
+    snprintf(buf, len, "%dkm", km);
+  }
+}
+
+}  // namespace radar_math

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,6 +1,12 @@
 ; ESP32-C3 Super Mini + 1.28" round GC9A01 (240×240)
 ; Board in Arduino IDE: "ESP32C3 Dev Module" or "MakerGO ESP32 C3 SuperMini"
 
+[env:native]
+platform = native
+test_framework = unity
+build_flags = -std=c++17 -DUNITY_INCLUDE_DOUBLE
+lib_deps =
+
 [env:supermini]
 platform = espressif32@6.5.0
 board = esp32-c3-devkitm-1

--- a/src/services/radar_location.cpp
+++ b/src/services/radar_location.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 
 #include "config.h"
+#include "radar_math.h"
 
 namespace services::location {
 
@@ -18,20 +19,11 @@ double s_lat = config::kDefaultRadarLat;
 double s_lon = config::kDefaultRadarLon;
 
 bool parseCoord(const char* text, double* out) {
-  if (text == nullptr || text[0] == '\0') {
-    return false;
-  }
-  char* end = nullptr;
-  const double v = strtod(text, &end);
-  if (end == text || (end != nullptr && *end != '\0')) {
-    return false;
-  }
-  *out = v;
-  return true;
+  return radar_math::parseCoord(text, out);
 }
 
 bool validLatLon(double lat, double lon) {
-  return lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0;
+  return radar_math::validLatLon(lat, lon);
 }
 
 void persist(double lat, double lon) {

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "hardware/display.h"
 #include "hardware/display_font.h"
+#include "radar_math.h"
 #include "services/adsb_client.h"
 #include "services/radar_location.h"
 #include "ui/radar_range.h"
@@ -192,15 +193,10 @@ void initPalette() {
       tft.color565(radar::kTagAltR, radar::kTagAltG, radar::kTagAltB);
 }
 
-constexpr float kKmPerDeg = 111.0f;
-
 void offsetKmFromCenter(float lat, float lon, float* dx_km, float* dy_km,
                         float* dist_km) {
-  *dx_km =
-      static_cast<float>(lon - services::location::lon()) * kKmPerDeg;
-  *dy_km =
-      static_cast<float>(lat - services::location::lat()) * kKmPerDeg;
-  *dist_km = sqrtf((*dx_km) * (*dx_km) + (*dy_km) * (*dy_km));
+  radar_math::offsetKm(services::location::lat(), services::location::lon(),
+                       lat, lon, dx_km, dy_km, dist_km);
 }
 
 float innerRingMaxKm() {
@@ -450,21 +446,10 @@ struct BeyondDotDrawItem {
   int dist_sq = 0;
 };
 
-void sortDrawItemsFarFirst(AircraftDrawItem* items, size_t count) {
+template <typename T>
+void sortFarFirst(T* items, size_t count) {
   for (size_t i = 1; i < count; ++i) {
-    const AircraftDrawItem key = items[i];
-    size_t j = i;
-    while (j > 0 && items[j - 1].dist_sq < key.dist_sq) {
-      items[j] = items[j - 1];
-      --j;
-    }
-    items[j] = key;
-  }
-}
-
-void sortBeyondDotsFarFirst(BeyondDotDrawItem* items, size_t count) {
-  for (size_t i = 1; i < count; ++i) {
-    const BeyondDotDrawItem key = items[i];
+    const T key = items[i];
     size_t j = i;
     while (j > 0 && items[j - 1].dist_sq < key.dist_sq) {
       items[j] = items[j - 1];
@@ -515,12 +500,12 @@ void drawAircraft() {
     ++dot_count;
   }
 
-  sortBeyondDotsFarFirst(dots, dot_count);
+  sortFarFirst(dots, dot_count);
   for (size_t d = 0; d < dot_count; ++d) {
     drawBeyondRingDot(dots[d].x, dots[d].y);
   }
 
-  sortDrawItemsFarFirst(items, draw_count);
+  sortFarFirst(items, draw_count);
   for (size_t d = 0; d < draw_count; ++d) {
     const size_t i = items[d].index;
     const int x = items[d].x;

--- a/src/ui/radar_range.cpp
+++ b/src/ui/radar_range.cpp
@@ -1,5 +1,6 @@
 #include "ui/radar_range.h"
 
+#include "radar_math.h"
 #include "ui/radar_theme.h"
 
 #include <Preferences.h>
@@ -15,7 +16,6 @@ constexpr char kPrefsNamespace[] = "planeradar";
 constexpr char kPrefsRangeKey[] = "rangeIdx";
 constexpr char kPrefsMilesKey[] = "useMiles";
 constexpr uint8_t kDefaultRangeIndex = 1;  // 10 km ring
-constexpr float kKmPerMile = 1.609344f;
 
 Preferences s_prefs;
 uint8_t s_range_index = kDefaultRangeIndex;
@@ -38,15 +38,7 @@ void saveUseMiles() {
 }
 
 bool portalCheckboxChecked(const char* value) {
-  if (value == nullptr || value[0] == '\0') {
-    return false;
-  }
-  // WiFiManager checkbox submits its value= attribute ("T", or "F" if we prefilled F).
-  if ((value[0] == 'T' || value[0] == 't' || value[0] == 'F' || value[0] == 'f') &&
-      value[1] == '\0') {
-    return true;
-  }
-  return strcmp(value, "on") == 0;
+  return radar_math::portalCheckboxChecked(value);
 }
 
 }  // namespace
@@ -87,13 +79,7 @@ void saveMilesFromPortal(const char* checkbox_value) {
 }
 
 void formatRing3Label(char* buf, size_t len, float ring3_km, bool use_miles) {
-  if (use_miles) {
-    const int mi = static_cast<int>(lroundf(ring3_km / kKmPerMile));
-    snprintf(buf, len, "%dmi", mi);
-  } else {
-    const int km = static_cast<int>(lroundf(ring3_km));
-    snprintf(buf, len, "%dkm", km);
-  }
+  radar_math::formatRing3Label(buf, len, ring3_km, use_miles);
 }
 
 void formatCurrentRing3Label(char* buf, size_t len) {

--- a/test/test_radar_math/test_radar_math.cpp
+++ b/test/test_radar_math/test_radar_math.cpp
@@ -1,0 +1,206 @@
+#include <unity.h>
+#include "radar_math.h"
+
+// --- offsetKm ---
+
+void test_offsetKm_north() {
+  float dx, dy, dist;
+  // 1° north from equator ≈ 111 km; no lon correction at equator
+  radar_math::offsetKm(0.0, 0.0, 1.0f, 0.0f, &dx, &dy, &dist);
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 0.0f, dx);
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 111.0f, dy);
+}
+
+void test_offsetKm_east_at_equator() {
+  float dx, dy, dist;
+  // At equator cos(0)=1, so 1° east ≈ 111 km
+  radar_math::offsetKm(0.0, 0.0, 0.0f, 1.0f, &dx, &dy, &dist);
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 111.0f, dx);
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 0.0f, dy);
+}
+
+void test_offsetKm_east_at_60deg_lat() {
+  float dx, dy, dist;
+  // At 60°N cos(60°)=0.5, so 1° east ≈ 55.5 km
+  radar_math::offsetKm(60.0, 0.0, 60.0f, 1.0f, &dx, &dy, &dist);
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 55.5f, dx);
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 0.0f, dy);
+}
+
+void test_offsetKm_dist_pythagorean() {
+  float dx, dy, dist;
+  // 3-4-5 triangle in km at equator: 3° east, 4° north → dist ≈ 555 km
+  // dx=333, dy=444 → dist=555
+  radar_math::offsetKm(0.0, 0.0, 4.0f, 3.0f, &dx, &dy, &dist);
+  const float expected_dist = sqrtf(dx * dx + dy * dy);
+  TEST_ASSERT_FLOAT_WITHIN(0.1f, expected_dist, dist);
+}
+
+void test_offsetKm_center_equals_aircraft() {
+  float dx, dy, dist;
+  radar_math::offsetKm(52.0, 4.9, 52.0f, 4.9f, &dx, &dy, &dist);
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, dx);
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, dy);
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, dist);
+}
+
+// --- portalCheckboxChecked ---
+
+void test_checkbox_T_is_checked() {
+  TEST_ASSERT_TRUE(radar_math::portalCheckboxChecked("T"));
+}
+
+void test_checkbox_t_is_checked() {
+  TEST_ASSERT_TRUE(radar_math::portalCheckboxChecked("t"));
+}
+
+void test_checkbox_on_is_checked() {
+  TEST_ASSERT_TRUE(radar_math::portalCheckboxChecked("on"));
+}
+
+void test_checkbox_empty_is_unchecked() {
+  TEST_ASSERT_FALSE(radar_math::portalCheckboxChecked(""));
+}
+
+void test_checkbox_null_is_unchecked() {
+  TEST_ASSERT_FALSE(radar_math::portalCheckboxChecked(nullptr));
+}
+
+void test_checkbox_F_is_unchecked() {
+  TEST_ASSERT_FALSE(radar_math::portalCheckboxChecked("F"));
+}
+
+void test_checkbox_f_is_unchecked() {
+  TEST_ASSERT_FALSE(radar_math::portalCheckboxChecked("f"));
+}
+
+void test_checkbox_garbage_is_unchecked() {
+  TEST_ASSERT_FALSE(radar_math::portalCheckboxChecked("yes"));
+}
+
+// --- validLatLon ---
+
+void test_validLatLon_origin() {
+  TEST_ASSERT_TRUE(radar_math::validLatLon(0.0, 0.0));
+}
+
+void test_validLatLon_extremes() {
+  TEST_ASSERT_TRUE(radar_math::validLatLon(90.0, 180.0));
+  TEST_ASSERT_TRUE(radar_math::validLatLon(-90.0, -180.0));
+}
+
+void test_validLatLon_bad_lat() {
+  TEST_ASSERT_FALSE(radar_math::validLatLon(91.0, 0.0));
+  TEST_ASSERT_FALSE(radar_math::validLatLon(-90.1, 0.0));
+}
+
+void test_validLatLon_bad_lon() {
+  TEST_ASSERT_FALSE(radar_math::validLatLon(0.0, 181.0));
+  TEST_ASSERT_FALSE(radar_math::validLatLon(0.0, -180.1));
+}
+
+// --- parseCoord ---
+
+void test_parseCoord_integer() {
+  double v = 0.0;
+  TEST_ASSERT_TRUE(radar_math::parseCoord("52", &v));
+  TEST_ASSERT_DOUBLE_WITHIN(0.0001, 52.0, v);
+}
+
+void test_parseCoord_decimal() {
+  double v = 0.0;
+  TEST_ASSERT_TRUE(radar_math::parseCoord("52.3676", &v));
+  TEST_ASSERT_DOUBLE_WITHIN(0.000001, 52.3676, v);
+}
+
+void test_parseCoord_negative() {
+  double v = 0.0;
+  TEST_ASSERT_TRUE(radar_math::parseCoord("-4.9041", &v));
+  TEST_ASSERT_DOUBLE_WITHIN(0.000001, -4.9041, v);
+}
+
+void test_parseCoord_empty_fails() {
+  double v = 99.0;
+  TEST_ASSERT_FALSE(radar_math::parseCoord("", &v));
+}
+
+void test_parseCoord_null_fails() {
+  double v = 99.0;
+  TEST_ASSERT_FALSE(radar_math::parseCoord(nullptr, &v));
+}
+
+void test_parseCoord_trailing_garbage_fails() {
+  double v = 99.0;
+  TEST_ASSERT_FALSE(radar_math::parseCoord("52abc", &v));
+}
+
+// --- formatRing3Label ---
+
+void test_formatRing3Label_km() {
+  char buf[12];
+  radar_math::formatRing3Label(buf, sizeof(buf), 10.0f, false);
+  TEST_ASSERT_EQUAL_STRING("10km", buf);
+}
+
+void test_formatRing3Label_miles() {
+  char buf[12];
+  // 10 km ÷ 1.609344 ≈ 6.21 → rounds to 6
+  radar_math::formatRing3Label(buf, sizeof(buf), 10.0f, true);
+  TEST_ASSERT_EQUAL_STRING("6mi", buf);
+}
+
+void test_formatRing3Label_5km() {
+  char buf[12];
+  radar_math::formatRing3Label(buf, sizeof(buf), 5.0f, false);
+  TEST_ASSERT_EQUAL_STRING("5km", buf);
+}
+
+void test_formatRing3Label_5km_miles() {
+  char buf[12];
+  // 5 km ÷ 1.609344 ≈ 3.11 → rounds to 3
+  radar_math::formatRing3Label(buf, sizeof(buf), 5.0f, true);
+  TEST_ASSERT_EQUAL_STRING("3mi", buf);
+}
+
+// ---
+
+void setUp() {}
+void tearDown() {}
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_offsetKm_north);
+  RUN_TEST(test_offsetKm_east_at_equator);
+  RUN_TEST(test_offsetKm_east_at_60deg_lat);
+  RUN_TEST(test_offsetKm_dist_pythagorean);
+  RUN_TEST(test_offsetKm_center_equals_aircraft);
+
+  RUN_TEST(test_checkbox_T_is_checked);
+  RUN_TEST(test_checkbox_t_is_checked);
+  RUN_TEST(test_checkbox_on_is_checked);
+  RUN_TEST(test_checkbox_empty_is_unchecked);
+  RUN_TEST(test_checkbox_null_is_unchecked);
+  RUN_TEST(test_checkbox_F_is_unchecked);
+  RUN_TEST(test_checkbox_f_is_unchecked);
+  RUN_TEST(test_checkbox_garbage_is_unchecked);
+
+  RUN_TEST(test_validLatLon_origin);
+  RUN_TEST(test_validLatLon_extremes);
+  RUN_TEST(test_validLatLon_bad_lat);
+  RUN_TEST(test_validLatLon_bad_lon);
+
+  RUN_TEST(test_parseCoord_integer);
+  RUN_TEST(test_parseCoord_decimal);
+  RUN_TEST(test_parseCoord_negative);
+  RUN_TEST(test_parseCoord_empty_fails);
+  RUN_TEST(test_parseCoord_null_fails);
+  RUN_TEST(test_parseCoord_trailing_garbage_fails);
+
+  RUN_TEST(test_formatRing3Label_km);
+  RUN_TEST(test_formatRing3Label_miles);
+  RUN_TEST(test_formatRing3Label_5km);
+  RUN_TEST(test_formatRing3Label_5km_miles);
+
+  return UNITY_END();
+}


### PR DESCRIPTION
- Extract pure logic (offsetKm, portalCheckboxChecked, validLatLon, parseCoord, formatRing3Label) into header-only lib/radar_math/radar_math.h
- Wire production .cpp files to delegate to radar_math (no behavior change)
- Fix longitude distortion: apply cos(lat) correction in offsetKm so east/west aircraft positions are accurate at non-equatorial latitudes
- Fix portalCheckboxChecked: 'F'/'f' now correctly returns false
- Collapse duplicate sortDrawItemsFarFirst/sortBeyondDotsFarFirst into a single sortFarFirst<T> template
- Add 27 Unity tests in test/test_radar_math/ covering all extracted logic
- Add native PlatformIO env; run tests in CI before the firmware build
- Add CLAUDE.md with build commands and architecture notes