### PR TITLE
Allow configuration after initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,18 @@ During setup you can also hold BOOT at power-on to force a credential reset (sam
 
 ## Wi‑Fi setup portal
 
+**First-time setup** (no saved Wi‑Fi):
+
 1. Connect to **`PlaneRadar-Setup`**
 2. Open **`http://plane-radar.local`** (preferred) or **`http://192.168.4.1`** — both are shown on the yellow setup screen; captive portal may open automatically
 3. Set home Wi‑Fi, then save
 
-mDNS hostname is configured in `config.h` as `kPortalHostname` (`plane-radar` → **plane-radar.local** on the setup AP). Some phones resolve `.local` slowly; use the IP if needed.
+**Reconfigure anytime** (after the device is on your network):
+
+1. Open **`http://plane-radar.local`** or **`http://<device-ip>`** (e.g. from your router or serial log at boot)
+2. Change Wi‑Fi, location, units, or runway overlay; save
+
+The same portal runs on the setup AP and on the device’s LAN IP while connected to Wi‑Fi. mDNS hostname is `plane-radar` → **plane-radar.local** (`kPortalHostname` in `config.h`). Some clients resolve `.local` slowly; use the IP if needed.
 
 **Custom fields** (stored in NVS):
 

--- a/include/services/adsb_client.h
+++ b/include/services/adsb_client.h
@@ -20,6 +20,10 @@ constexpr size_t kMaxAircraft = 64;
 size_t aircraftCount();
 const Aircraft* aircraftList();
 
+/** Hook invoked during long HTTP I/O (e.g. wifiLoop). Optional. */
+using PollFn = void (*)();
+void setPollFn(PollFn fn);
+
 /** Fetch aircraft within fetch_radius_km of center_lat/lon from adsb.fi. */
 bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km);
 

--- a/include/services/wifi_setup.h
+++ b/include/services/wifi_setup.h
@@ -7,6 +7,8 @@ void wifiResetCredentialsAndReboot();
 bool wifiSetupConnect();
 /** Reconnect using saved creds; never opens the captive portal. */
 bool wifiReconnect();
+/** Keeps the LAN config portal alive; call every loop() iteration. */
+void wifiLoop();
 bool wifiBootButtonPressed();
 /** GPIO + interrupt setup; call once early in setup(). */
 void bootButtonInit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,6 +75,7 @@ void setup() {
   }
   services::location::init();
   ui::radar::rangeInit();
+  services::adsb::setPollFn(wifiLoop);
 
   if (wifiSetupConnect()) {
     showRadarIfConnected();
@@ -83,6 +84,7 @@ void setup() {
 
 void loop() {
   handleBootButton();
+  wifiLoop();
 
   if (WiFi.status() != WL_CONNECTED) {
     if (g_radar_visible) {

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -15,9 +15,75 @@ namespace {
 
 constexpr char kApiBase[] = "https://opendata.adsb.fi/api/v3/lat/";
 constexpr float kKmPerNm = 1.852f;
+constexpr int kConnectAttemptMs = 200;
+constexpr unsigned long kRequestTimeoutMs = 10000;
 
 Aircraft s_aircraft[kMaxAircraft];
 size_t s_aircraft_count = 0;
+PollFn s_poll_fn = nullptr;
+
+void pollNetwork() {
+  if (s_poll_fn != nullptr) {
+    s_poll_fn();
+  }
+}
+
+int performGetWithPoll(HTTPClient& http) {
+  http.setConnectTimeout(kConnectAttemptMs);
+  const unsigned long deadline = millis() + kRequestTimeoutMs;
+  while (millis() < deadline) {
+    pollNetwork();
+    const int code = http.GET();
+    if (code > 0) {
+      return code;
+    }
+    if (code != HTTPC_ERROR_CONNECTION_REFUSED &&
+        code != HTTPC_ERROR_NOT_CONNECTED) {
+      return code;
+    }
+    delay(5);
+  }
+  return HTTPC_ERROR_READ_TIMEOUT;
+}
+
+bool readResponseBodyWithPoll(HTTPClient& http, String& payload) {
+  WiFiClient* stream = http.getStreamPtr();
+  if (stream == nullptr) {
+    return false;
+  }
+
+  const int content_length = http.getSize();
+  if (content_length > 0) {
+    payload.reserve(static_cast<unsigned>(content_length + 1));
+  }
+
+  uint8_t buffer[512];
+  const unsigned long deadline = millis() + kRequestTimeoutMs;
+  while (millis() < deadline) {
+    pollNetwork();
+    const int available = stream->available();
+    if (available > 0) {
+      const int to_read =
+          available > static_cast<int>(sizeof(buffer)) ? static_cast<int>(sizeof(buffer))
+                                                       : available;
+      const int read_bytes = stream->readBytes(buffer, to_read);
+      if (read_bytes > 0) {
+        payload.concat(reinterpret_cast<const char*>(buffer),
+                       static_cast<unsigned>(read_bytes));
+      }
+    }
+    if (content_length > 0 &&
+        static_cast<int>(payload.length()) >= content_length) {
+      break;
+    }
+    if (!http.connected() && stream->available() <= 0) {
+      break;
+    }
+    delay(1);
+  }
+
+  return payload.length() > 0;
+}
 
 float kmToNauticalMiles(float km) { return km / kKmPerNm; }
 
@@ -133,6 +199,8 @@ void fillTagFields(Aircraft* ac, const JsonObject& plane) {
 
 }  // namespace
 
+void setPollFn(PollFn fn) { s_poll_fn = fn; }
+
 size_t aircraftCount() { return s_aircraft_count; }
 
 const Aircraft* aircraftList() { return s_aircraft; }
@@ -156,15 +224,20 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
     return false;
   }
 
-  http.setTimeout(10000);
-  const int code = http.GET();
+  http.setTimeout(kRequestTimeoutMs);
+  const int code = performGetWithPoll(http);
   if (code != HTTP_CODE_OK) {
     Serial.printf("adsb: HTTP %d\n", code);
     http.end();
     return false;
   }
 
-  const String payload = http.getString();
+  String payload;
+  if (!readResponseBodyWithPoll(http, payload)) {
+    Serial.println("adsb: empty response");
+    http.end();
+    return false;
+  }
   http.end();
 
   JsonDocument doc;

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -59,6 +59,13 @@ constexpr char kWifiPrefsNamespace[] = "wifi";
 constexpr char kPrefsForcePortalKey[] = "portal";
 
 bool s_force_config_portal = false;
+WiFiManager s_wm;
+bool s_wm_configured = false;
+
+void ensureWifiManager();
+void startLanWebPortal();
+void stopLanWebPortal();
+bool wifiLinkUp();
 
 constexpr int kCoordParamLen = 20;
 constexpr char kCoordInputAttrs[] =
@@ -163,14 +170,15 @@ bool storedWifiCredentials() {
 }
 
 void eraseWifiCredentials() {
+  stopLanWebPortal();
   WiFi.setAutoReconnect(false);
   WiFi.mode(WIFI_OFF);
   delay(100);
 
+  ensureWifiManager();
   WiFi.persistent(true);
-  WiFiManager wm;
-  wm.resetSettings();
-  wm.erase();
+  s_wm.resetSettings();
+  s_wm.erase();
   WiFi.disconnect(true, true);
   WiFi.persistent(false);
 
@@ -201,18 +209,51 @@ void onConfigPortalApStarted(WiFiManager*) {
 #endif
 }
 
-void configureWifiManager(WiFiManager& wm) {
-  wm.setConfigPortalTimeout(config::kWifiPortalTimeoutSec);
-  wm.setAPStaticIPConfig(IPAddress(192, 168, 4, 1), IPAddress(192, 168, 4, 1),
-                         IPAddress(255, 255, 255, 0));
-  wm.setHostname(config::kPortalHostname);
-  wm.setAPCallback(onConfigPortalApStarted);
-  attachPortalParams(wm);
-}
-
 bool wifiLinkUp() {
   return WiFi.status() == WL_CONNECTED &&
          WiFi.localIP() != IPAddress(0, 0, 0, 0);
+}
+
+void ensureWifiManager() {
+  if (s_wm_configured) {
+    return;
+  }
+  s_wm.setConfigPortalTimeout(config::kWifiPortalTimeoutSec);
+  s_wm.setAPStaticIPConfig(IPAddress(192, 168, 4, 1), IPAddress(192, 168, 4, 1),
+                           IPAddress(255, 255, 255, 0));
+  s_wm.setHostname(config::kPortalHostname);
+  s_wm.setAPCallback(onConfigPortalApStarted);
+  attachPortalParams(s_wm);
+  s_wm_configured = true;
+}
+
+void startLanWebPortal() {
+  if (!wifiLinkUp() || s_wm.getWebPortalActive() ||
+      s_wm.getConfigPortalActive()) {
+    return;
+  }
+  refreshPortalParamDefaults();
+  WiFi.mode(WIFI_STA);
+  s_wm.setConfigPortalBlocking(false);
+#ifdef WM_MDNS
+  MDNS.end();
+  if (MDNS.begin(config::kPortalHostname)) {
+    MDNS.addService("http", "tcp", 80);
+  }
+#endif
+  s_wm.startWebPortal();
+  Serial.printf("LAN config: http://%s.local or http://%s\n",
+                config::kPortalHostname, WiFi.localIP().toString().c_str());
+}
+
+void stopLanWebPortal() {
+  if (!s_wm.getWebPortalActive()) {
+    return;
+  }
+  s_wm.stopWebPortal();
+#ifdef WM_MDNS
+  MDNS.end();
+#endif
 }
 
 void prepareSta() {
@@ -277,25 +318,26 @@ bool connectSavedNetwork(bool show_ui) {
     return false;
   }
 
-  WiFiManager wm;
-  const String ssid = wm.getWiFiSSID();
+  ensureWifiManager();
+  const String ssid = s_wm.getWiFiSSID();
   if (ssid.length() == 0) {
     return false;
   }
-  const String pass = wm.getWiFiPass();
+  const String pass = s_wm.getWiFiPass();
   return tryConnectWithUi(ssid, pass, show_ui);
 }
 
-bool openConfigPortal(WiFiManager& wm) {
+bool openConfigPortal() {
+  stopLanWebPortal();
   WiFi.disconnect(true);
   WiFi.mode(WIFI_OFF);
   delay(50);
   statusScreenPortal();
-  wm.setConfigPortalBlocking(false);
-  wm.startConfigPortal(config::kPortalApName);
-  while (wm.getConfigPortalActive()) {
+  s_wm.setConfigPortalBlocking(false);
+  s_wm.startConfigPortal(config::kPortalApName);
+  while (s_wm.getConfigPortalActive()) {
     bootButtonPollLongPress();
-    if (wm.process()) {
+    if (s_wm.process()) {
       return true;
     }
     delay(10);
@@ -371,8 +413,24 @@ bool wifiReconnect() {
   return connectSavedNetwork(true);
 }
 
+void wifiLoop() {
+  ensureWifiManager();
+  if (wifiLinkUp()) {
+    if (!s_wm.getWebPortalActive() && !s_wm.getConfigPortalActive()) {
+      startLanWebPortal();
+    }
+    if (s_wm.getWebPortalActive() || s_wm.getConfigPortalActive()) {
+      bootButtonPollLongPress();
+      s_wm.process();
+    }
+  } else {
+    stopLanWebPortal();
+  }
+}
+
 bool wifiSetupConnect() {
   initBootButton();
+  ensureWifiManager();
 
   const bool force_portal = consumeForceConfigPortal();
   WiFi.setAutoReconnect(false);
@@ -383,12 +441,9 @@ bool wifiSetupConnect() {
     delay(100);
   }
 
-  WiFiManager wm;
-  configureWifiManager(wm);
-
   if (force_portal) {
     Serial.println("Opening WiFi setup portal (after reset)");
-    if (openConfigPortal(wm) && wifiLinkUp()) {
+    if (openConfigPortal() && wifiLinkUp()) {
       WiFi.setAutoReconnect(true);
       Serial.printf("Connected: %s  IP %s\n", WiFi.SSID().c_str(),
                     WiFi.localIP().toString().c_str());
@@ -421,7 +476,7 @@ bool wifiSetupConnect() {
     Serial.println("No saved WiFi — opening setup portal");
   }
 
-  if (openConfigPortal(wm) && wifiLinkUp()) {
+  if (openConfigPortal() && wifiLinkUp()) {
     WiFi.setAutoReconnect(true);
     Serial.printf("Connected: %s  IP %s\n", WiFi.SSID().c_str(),
                   WiFi.localIP().toString().c_str());


### PR DESCRIPTION
This allows updating settings (lat/lng & displayed fields) after initial configuration via http://plane-radar.local 