### PR TITLE
Fix JSON parse error: NoMemory and JSON parse error: EmptyInput when fetching large adsb payload.

### DIFF
--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -232,20 +232,25 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
     return false;
   }
 
-  String payload;
-  if (!readResponseBodyWithPoll(http, payload)) {
-    Serial.println("adsb: empty response");
-    http.end();
-    return false;
-  }
-  http.end();
+  // String payload;
+  // if (!readResponseBodyWithPoll(http, payload)) {
+  //   Serial.println("adsb: empty response");
+  //   http.end();
+  //   return false;
+  // }
 
+  WiFiClient* stream = http.getStreamPtr();
+  if (!stream) { 
+    http.end(); return false; 
+  }
+  
   JsonDocument doc;
-  const DeserializationError err = deserializeJson(doc, payload);
+  const DeserializationError err = deserializeJson(doc, *stream);
   if (err) {
     Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
     return false;
   }
+  http.end();
 
   JsonArray ac = doc["ac"].as<JsonArray>();
   if (ac.isNull()) {

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -215,6 +215,11 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
   url += "/dist/";
   url += String(dist_nm, 1);
 
+  if (ESP.getFreeHeap() < 50000) {
+    Serial.printf("adsb: heap too low (%u), skipping\n", ESP.getFreeHeap());
+    return false;
+  }
+
   WiFiClientSecure client;
   client.setInsecure();
 

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -232,13 +232,6 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
     return false;
   }
 
-  // String payload;
-  // if (!readResponseBodyWithPoll(http, payload)) {
-  //   Serial.println("adsb: empty response");
-  //   http.end();
-  //   return false;
-  // }
-
   WiFiClient* stream = http.getStreamPtr();
   if (!stream) { 
     http.end(); return false; 

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -237,8 +237,29 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
     http.end(); return false; 
   }
   
+  static JsonDocument filter;
+  static bool filter_built = false;
+  if (!filter_built) {
+    JsonObject f = filter["ac"][0].to<JsonObject>();
+    f["lat"]          = true;
+    f["lon"]          = true;
+    f["flight"]       = true;
+    f["hex"]          = true;
+    f["t"]            = true;
+    f["alt_baro"]     = true;
+    f["alt_geom"]     = true;
+    f["true_heading"] = true;
+    f["mag_heading"]  = true;
+    f["track"]        = true;
+    f["dir"]          = true;
+    f["gs"]           = true;
+    f["tas"]          = true;
+    f["ias"]          = true;
+    filter_built = true;
+  }
+
   JsonDocument doc;
-  const DeserializationError err = deserializeJson(doc, *stream);
+  const DeserializationError err = deserializeJson(doc, *stream, DeserializationOption::Filter(filter));
   if (err) {
     Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
     return false;

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -239,7 +239,8 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
 
   WiFiClient* stream = http.getStreamPtr();
   if (!stream) { 
-    http.end(); return false; 
+    http.end(); 
+    return false; 
   }
   
   static JsonDocument filter;
@@ -267,6 +268,7 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
   const DeserializationError err = deserializeJson(doc, *stream, DeserializationOption::Filter(filter));
   if (err) {
     Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
+    http.end();
     return false;
   }
   http.end();


### PR DESCRIPTION
when getting a big payload the heap would fill up and cause the JSON parser to fail.
this would result in error: NoMemory and JSON parse error: EmptyInput.

By changing the JSON parser to take the http stream it can directly parse the data without having to store it in a big buffer first.
By implementing a filter only the nodes actually used will get stored to save space on the heap.
Added a check if enough heap is available and if not skip this current fetch.

This is my first time contributing to another project. Feedback is welcome!