### PR TITLE
Show altitude in metres instead of feet

### DIFF
--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -183,7 +183,8 @@ void formatAltitudeTag(const JsonObject& plane, char* out, size_t out_len) {
   float alt = 0.0f;
   if (readJsonFloat(plane, "alt_baro", &alt) ||
       readJsonFloat(plane, "alt_geom", &alt)) {
-    snprintf(out, out_len, "%d ft", static_cast<int>(lroundf(alt)));
+    const int alt_m = static_cast<int>(lroundf(alt * 0.3048f));
+    snprintf(out, out_len, "%d m", alt_m);
   }
 }
 


### PR DESCRIPTION
Convert alt_baro/alt_geom from feet to metres (× 0.3048) before display.

https://claude.ai/code/session_01MapRkZ7CQkz8fAS8VMcXNE