### PR TITLE
fix: set WiFi TX power to 8.5dBm in AP and STA modes

### DIFF
--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -195,6 +195,7 @@ void resetWifiCredentials() {
 }
 
 void onConfigPortalApStarted(WiFiManager*) {
+  WiFi.setTxPower(WIFI_POWER_8_5dBm);
   statusScreenPortal();
 #ifdef WM_MDNS
   if (MDNS.begin(config::kPortalHostname)) {
@@ -257,6 +258,7 @@ void stopLanWebPortal() {
 }
 
 void prepareSta() {
+  WiFi.setTxPower(WIFI_POWER_8_5dBm);
   WiFi.mode(WIFI_STA);
   WiFi.setSleep(WIFI_PS_NONE);
   WiFi.setAutoReconnect(true);


### PR DESCRIPTION
Adjusted TX power level for cheaper ESP32-C3 devices.