### PR TITLE
Add ONX2432G028 board support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pio
+.venv-platformio/
 release/
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json

--- a/boards/onx2432g028.json
+++ b/boards/onx2432g028.json
@@ -1,0 +1,48 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ONX2432G028",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32_s3r8n16"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "OpenNextion ONX2432G028 (ESP32-S3R8, 16MB Flash)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/OpenNextion",
+  "vendor": "OpenNextion"
+}

--- a/include/config.h
+++ b/include/config.h
@@ -57,7 +57,11 @@ constexpr int kDisplayHeight = kBoardOnx2432g028 ? 320 : 240;
 
 constexpr int kRadarViewportSize = kDisplayWidth < 240 ? kDisplayWidth : 240;
 constexpr int kRadarViewportX = (kDisplayWidth - kRadarViewportSize) / 2;
-constexpr int kRadarViewportY = (kDisplayHeight - kRadarViewportSize) / 2;
+constexpr int kRadarViewportY = kBoardOnx2432g028
+                                  ? 0
+                                  : (kDisplayHeight - kRadarViewportSize) / 2;
+constexpr bool kRadarInfoPanelEnabled = kBoardOnx2432g028;
+constexpr int kRadarInfoPanelY = 246;
 
 constexpr uint32_t kDisplaySpiWriteHz =
     kBoardOnx2432g028 ? 40000000 : 40000000;

--- a/include/config.h
+++ b/include/config.h
@@ -6,6 +6,12 @@
 
 namespace config {
 
+#if defined(BOARD_ONX2432G028)
+constexpr bool kBoardOnx2432g028 = true;
+#else
+constexpr bool kBoardOnx2432g028 = false;
+#endif
+
 // --- Wi-Fi portal ---
 constexpr char kPortalApName[] = "PlaneRadar-Setup";
 constexpr char kPortalIp[] = "192.168.4.1";
@@ -23,26 +29,41 @@ constexpr unsigned long kWifiDownGraceMs = 4000;
 /** Minimum interval between background reconnect tries. */
 constexpr unsigned long kWifiReconnectIntervalMs = 15000;
 
-// --- BOOT button (ESP32-C3 Super Mini, active LOW) ---
-constexpr gpio_num_t kBootPin = GPIO_NUM_9;
+// --- User input (active LOW when present) ---
+constexpr bool kHasBootButton = true;
+constexpr bool kBootTapChangesRange = true;
+constexpr gpio_num_t kBootPin =
+    kBoardOnx2432g028 ? GPIO_NUM_0 : GPIO_NUM_9;
 constexpr unsigned long kBootResetHoldMs = 3000UL;
 /** Ignore BOOT taps shorter than this (debounce). */
 constexpr unsigned long kBootTapMinMs = 40UL;
 
-// --- Display: GC9A01 1.28" round 240×240 (SPI) ---
-constexpr gpio_num_t kDisplayPinRst = GPIO_NUM_0;
-constexpr gpio_num_t kDisplayPinCs = GPIO_NUM_1;
-constexpr gpio_num_t kDisplayPinDc = GPIO_NUM_10;
-constexpr gpio_num_t kDisplayPinMosi = GPIO_NUM_3;  // display SDA
-constexpr gpio_num_t kDisplayPinSclk = GPIO_NUM_4;  // display SCL
+// --- Display ---
+constexpr gpio_num_t kDisplayPinRst =
+    kBoardOnx2432g028 ? GPIO_NUM_NC : GPIO_NUM_0;
+constexpr gpio_num_t kDisplayPinCs =
+    kBoardOnx2432g028 ? GPIO_NUM_2 : GPIO_NUM_1;
+constexpr gpio_num_t kDisplayPinDc =
+    kBoardOnx2432g028 ? GPIO_NUM_3 : GPIO_NUM_10;
+constexpr gpio_num_t kDisplayPinMosi =
+    kBoardOnx2432g028 ? GPIO_NUM_1 : GPIO_NUM_3;
+constexpr gpio_num_t kDisplayPinSclk =
+    kBoardOnx2432g028 ? GPIO_NUM_5 : GPIO_NUM_4;
+constexpr gpio_num_t kDisplayPinBl =
+    kBoardOnx2432g028 ? GPIO_NUM_6 : GPIO_NUM_NC;
 
-constexpr int kDisplayWidth = 240;
-constexpr int kDisplayHeight = 240;
+constexpr int kDisplayWidth = kBoardOnx2432g028 ? 240 : 240;
+constexpr int kDisplayHeight = kBoardOnx2432g028 ? 320 : 240;
 
-constexpr uint32_t kDisplaySpiWriteHz = 40000000;
-// GC9A01 modules often need invert + BGR for correct black/green output
-constexpr bool kDisplayInvert = true;
+constexpr int kRadarViewportSize = kDisplayWidth < 240 ? kDisplayWidth : 240;
+constexpr int kRadarViewportX = (kDisplayWidth - kRadarViewportSize) / 2;
+constexpr int kRadarViewportY = (kDisplayHeight - kRadarViewportSize) / 2;
+
+constexpr uint32_t kDisplaySpiWriteHz =
+    kBoardOnx2432g028 ? 40000000 : 40000000;
+constexpr bool kDisplayInvert = kBoardOnx2432g028 ? false : true;
 constexpr bool kDisplayRgbOrder = true;
+constexpr uint8_t kDisplayRotation = 0;
 
 // --- Radar center defaults (overridden via WiFi setup portal) ---
 constexpr double kDefaultRadarLat = 52.3676;

--- a/include/hardware/board_support.h
+++ b/include/hardware/board_support.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void boardInitBeforeDisplay();

--- a/include/hardware/display.h
+++ b/include/hardware/display.h
@@ -5,3 +5,4 @@
 extern LGFX tft;
 
 void displayInit();
+void displayRadarBackground();

--- a/include/hardware/lgfx_config.hpp
+++ b/include/hardware/lgfx_config.hpp
@@ -5,10 +5,14 @@
 
 #include "config.h"
 
-/** LovyanGFX device: GC9A01 on SPI. Pin values come from config.h. */
+/** LovyanGFX device. Panel selection and pins come from config.h build flags. */
 class LGFX : public lgfx::LGFX_Device {
   lgfx::Bus_SPI _bus;
+#if defined(BOARD_ONX2432G028)
+  lgfx::Panel_ST7789 _panel;
+#else
   lgfx::Panel_GC9A01 _panel;
+#endif
 
 public:
   LGFX() {
@@ -27,8 +31,21 @@ public:
       auto cfg = _panel.config();
       cfg.pin_cs = static_cast<int>(config::kDisplayPinCs);
       cfg.pin_rst = static_cast<int>(config::kDisplayPinRst);
+      cfg.pin_busy = -1;
+      cfg.panel_width = config::kDisplayWidth;
+      cfg.panel_height = config::kDisplayHeight;
+      cfg.memory_width = config::kDisplayWidth;
+      cfg.memory_height = config::kDisplayHeight;
+      cfg.offset_x = 0;
+      cfg.offset_y = 0;
+      cfg.offset_rotation = 0;
+      cfg.dummy_read_pixel = 8;
+      cfg.dummy_read_bits = 1;
+      cfg.readable = false;
       cfg.invert = config::kDisplayInvert;
       cfg.rgb_order = config::kDisplayRgbOrder;
+      cfg.dlen_16bit = false;
+      cfg.bus_shared = false;
       _panel.config(cfg);
     }
     setPanel(&_panel);

--- a/include/ui/radar_display.h
+++ b/include/ui/radar_display.h
@@ -8,4 +8,7 @@ void radarDisplayDraw();
 /** Redraw aircraft only (blits cached grid; no full-screen clear). */
 void radarDisplayRefreshAircraft();
 
+/** Refresh dynamic info panel without refetching ADS-B data. */
+void radarDisplayRefreshInfo();
+
 }  // namespace ui

--- a/include/ui/radar_theme.h
+++ b/include/ui/radar_theme.h
@@ -2,11 +2,17 @@
 
 #include <cstdint>
 
+#include "config.h"
+
 namespace ui::radar {
 
 constexpr int kSize = 240;
-constexpr int kCenterX = kSize / 2;
-constexpr int kCenterY = kSize / 2;
+constexpr int kOffsetX = config::kRadarViewportX;
+constexpr int kOffsetY = config::kRadarViewportY;
+constexpr int kRight = kOffsetX + kSize - 1;
+constexpr int kBottom = kOffsetY + kSize - 1;
+constexpr int kCenterX = kOffsetX + kSize / 2;
+constexpr int kCenterY = kOffsetY + kSize / 2;
 
 /** Outermost grid ring (inside edge labels). */
 constexpr int kGridOuterRadius = 107;

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,3 +24,21 @@ lib_deps =
   lovyan03/LovyanGFX@^1.2.7
   tzapu/WiFiManager@^2.0.17
   bblanchon/ArduinoJson@^7.4.2
+
+[env:onx2432g028]
+platform = espressif32@6.5.0
+board = onx2432g028
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = partitions/plane_radar.csv
+extra_scripts = post:scripts/merge_firmware.py
+board_build.embed_files = data/ui_font.vlw
+build_flags =
+  -std=gnu++17
+  -DWM_NODEBUG
+  -DWM_MDNS
+  -DBOARD_ONX2432G028
+lib_deps =
+  lovyan03/LovyanGFX@^1.2.7
+  tzapu/WiFiManager@^2.0.17
+  bblanchon/ArduinoJson@^7.4.2

--- a/src/hardware/board_support.cpp
+++ b/src/hardware/board_support.cpp
@@ -1,0 +1,73 @@
+#include "hardware/board_support.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "config.h"
+
+namespace {
+
+#if defined(BOARD_ONX2432G028)
+
+constexpr uint8_t kPcf8574Addr = 0x38;
+constexpr int kPcfExioLcdRst = 6;
+constexpr int kPcfExioSdCs = 7;
+constexpr int kBoardI2cSda = 8;
+constexpr int kBoardI2cScl = 7;
+
+uint8_t s_pcf_shadow = 0xFF;
+bool s_pcf_ready = false;
+
+bool pcfWrite(uint8_t value) {
+  Wire.beginTransmission(kPcf8574Addr);
+  Wire.write(value);
+  const uint8_t error = Wire.endTransmission();
+  if (error != 0) {
+    Serial.printf("board: PCF8574 write failed (%u)\n", error);
+    return false;
+  }
+  s_pcf_shadow = value;
+  return true;
+}
+
+bool pcfSetOutput(int bit, bool high) {
+  const uint8_t mask = static_cast<uint8_t>(1u << bit);
+  const uint8_t next = high ? (s_pcf_shadow | mask) : (s_pcf_shadow & ~mask);
+  return pcfWrite(next);
+}
+
+void initOnx2432g028IoExpander() {
+  if (s_pcf_ready) {
+    return;
+  }
+
+  Wire.begin(kBoardI2cSda, kBoardI2cScl);
+  Wire.setClock(400000);
+
+  s_pcf_ready = pcfWrite(0xFF);
+  if (!s_pcf_ready) {
+    Serial.println("board: continuing without PCF8574 init");
+    return;
+  }
+
+  pcfSetOutput(kPcfExioSdCs, true);
+  pcfSetOutput(kPcfExioLcdRst, false);
+  delay(200);
+  pcfSetOutput(kPcfExioLcdRst, true);
+  delay(200);
+}
+
+#endif
+
+}  // namespace
+
+void boardInitBeforeDisplay() {
+  if (config::kDisplayPinBl != GPIO_NUM_NC) {
+    pinMode(config::kDisplayPinBl, OUTPUT);
+    digitalWrite(config::kDisplayPinBl, LOW);
+  }
+
+#if defined(BOARD_ONX2432G028)
+  initOnx2432g028IoExpander();
+#endif
+}

--- a/src/hardware/display.cpp
+++ b/src/hardware/display.cpp
@@ -1,13 +1,23 @@
 #include "hardware/display.h"
 
+#include <Arduino.h>
+
+#include "config.h"
+#include "hardware/board_support.h"
 #include "hardware/display_font.h"
 
 LGFX tft;
 
 void displayInit() {
+  boardInitBeforeDisplay();
   tft.init();
-  tft.setRotation(0);
+  tft.setRotation(config::kDisplayRotation);
+  if (config::kDisplayPinBl != GPIO_NUM_NC) {
+    digitalWrite(config::kDisplayPinBl, HIGH);
+  }
   tft.setBrightness(255);
   tft.setTextWrap(false);
   displayFontInit();
 }
+
+void displayRadarBackground() { tft.fillScreen(config::kColorBlack); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@ bool g_radar_visible = false;
 unsigned long g_wifi_down_since = 0;
 unsigned long g_last_reconnect_ms = 0;
 unsigned long g_last_adsb_fetch_ms = 0;
+unsigned long g_last_info_refresh_ms = 0;
 
 void showRadarIfConnected() {
   if (WiFi.status() != WL_CONNECTED) {
@@ -109,9 +110,17 @@ void loop() {
     g_wifi_down_since = 0;
     if (!g_radar_visible) {
       showRadarIfConnected();
-    } else if (millis() - g_last_adsb_fetch_ms >= config::kAdsbFetchIntervalMs) {
-      g_last_adsb_fetch_ms = millis();
-      fetchAndDrawAircraft();
+    } else {
+      const unsigned long now = millis();
+      if (now - g_last_adsb_fetch_ms >= config::kAdsbFetchIntervalMs) {
+        fetchAndDrawAircraft();
+        const unsigned long after_fetch_ms = millis();
+        g_last_adsb_fetch_ms = after_fetch_ms;
+        g_last_info_refresh_ms = after_fetch_ms;
+      } else if (now - g_last_info_refresh_ms >= 1000UL) {
+        g_last_info_refresh_ms = now;
+        ui::radarDisplayRefreshInfo();
+      }
     }
   }
 

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -26,6 +26,9 @@ bool s_long_press_handled = false;
 bool s_boot_interrupt_attached = false;
 
 void IRAM_ATTR onBootButtonIsr() {
+  if (!config::kHasBootButton) {
+    return;
+  }
   const bool down = digitalRead(config::kBootPin) == LOW;
   const unsigned long now = millis();
   portENTER_CRITICAL_ISR(&s_boot_mux);
@@ -34,7 +37,8 @@ void IRAM_ATTR onBootButtonIsr() {
     s_boot_down_ms = now;
   } else if (s_boot_is_down) {
     const unsigned long held = now - s_boot_down_ms;
-    if (held >= config::kBootTapMinMs && held < config::kBootResetHoldMs) {
+    if (config::kBootTapChangesRange && held >= config::kBootTapMinMs &&
+        held < config::kBootResetHoldMs) {
       s_boot_tap_pending = true;
     }
     s_boot_is_down = false;
@@ -43,6 +47,9 @@ void IRAM_ATTR onBootButtonIsr() {
 }
 
 void initBootButton() {
+  if (!config::kHasBootButton) {
+    return;
+  }
   pinMode(config::kBootPin, INPUT_PULLUP);
   if (s_boot_interrupt_attached) {
     return;
@@ -361,12 +368,18 @@ bool wifiShowsSetupScreenOnBoot() {
 }
 
 bool wifiBootButtonPressed() {
+  if (!config::kHasBootButton) {
+    return false;
+  }
   return digitalRead(config::kBootPin) == LOW;
 }
 
 void bootButtonInit() { initBootButton(); }
 
 bool bootButtonConsumeTap() {
+  if (!config::kHasBootButton || !config::kBootTapChangesRange) {
+    return false;
+  }
   portENTER_CRITICAL(&s_boot_mux);
   const bool tap = s_boot_tap_pending;
   if (tap) {
@@ -377,6 +390,9 @@ bool bootButtonConsumeTap() {
 }
 
 void bootButtonPollLongPress() {
+  if (!config::kHasBootButton) {
+    return;
+  }
   if (wifiBootButtonPressed()) {
     portENTER_CRITICAL(&s_boot_mux);
     if (!s_boot_is_down) {

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -259,7 +259,7 @@ bool beyondRingEdgeDotFromLatLon(float lat, float lon, int* out_x, int* out_y) {
 
   const int cx = radar::kCenterX;
   const int cy = radar::kCenterY;
-  const int rim_r = radar::kCenterX - radar::kBeyondRingScreenMarginPx;
+  const int rim_r = radar::kSize / 2 - radar::kBeyondRingScreenMarginPx;
   const float angle_rad = atan2f(dx_km, dy_km);
 
   *out_x = cx + static_cast<int>(lroundf(sinf(angle_rad) * rim_r));
@@ -418,14 +418,14 @@ void drawAircraftTag(int x, int y, const services::adsb::Aircraft& plane) {
   int anchor_x = 0;
   if (tag_on_right) {
     anchor_x = x + symbol_half + radar::kAircraftLabelGapPx;
-    anchor_x = std::min(anchor_x, radar::kSize - block_w - 1);
+    anchor_x = std::min(anchor_x, radar::kRight - block_w);
     s_draw->setTextDatum(textdatum_t::top_left);
   } else {
     anchor_x = x - symbol_half - radar::kAircraftLabelGapPx;
-    anchor_x = std::max(anchor_x, block_w + 1);
+    anchor_x = std::max(anchor_x, radar::kOffsetX + block_w + 1);
     s_draw->setTextDatum(textdatum_t::top_right);
   }
-  ly = std::max(1, std::min(ly, radar::kSize - block_h - 1));
+  ly = std::max(radar::kOffsetY + 1, std::min(ly, radar::kBottom - block_h));
 
   if (plane.callsign[0] != '\0') {
     s_draw->setTextColor(radar::kColorLabel, radar::kColorBackground);
@@ -616,13 +616,12 @@ void drawCenterDot(int cx, int cy) {
 void drawCardinalLabels() {
   const int cx = radar::kCenterX;
   const int cy = radar::kCenterY;
-  const int edge = radar::kSize - 1;
-
-  drawCardinalLabel("N", cx, radar::kCardinalNorthOffsetY, textdatum_t::top_center);
-  drawCardinalLabel("S", cx, edge + radar::kCardinalSouthOffsetY,
+  drawCardinalLabel("N", cx, radar::kOffsetY + radar::kCardinalNorthOffsetY,
+                    textdatum_t::top_center);
+  drawCardinalLabel("S", cx, radar::kBottom + radar::kCardinalSouthOffsetY,
                     textdatum_t::bottom_center);
-  drawCardinalLabel("W", 0, cy, textdatum_t::middle_left);
-  drawCardinalLabel("E", edge, cy, textdatum_t::middle_right);
+  drawCardinalLabel("W", radar::kOffsetX, cy, textdatum_t::middle_left);
+  drawCardinalLabel("E", radar::kRight, cy, textdatum_t::middle_right);
 }
 
 int scaleLabelAnchorX(int cx, int outer_radius) {
@@ -661,7 +660,7 @@ bool ensureFrameSprite() {
     return true;
   }
   s_frame.setColorDepth(16);
-  if (!s_frame.createSprite(radar::kSize, radar::kSize)) {
+  if (!s_frame.createSprite(config::kDisplayWidth, config::kDisplayHeight)) {
     Serial.println("radar: frame sprite alloc failed");
     return false;
   }
@@ -687,6 +686,7 @@ void renderFrame() {
 void radarDisplayDraw() {
   initPalette();
   initLabelMetrics();
+  displayRadarBackground();
 
   if (ensureFrameSprite()) {
     renderFrame();

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -2,8 +2,11 @@
 
 #include <lgfx/v1/lgfx_fonts.hpp>
 
+#include <Arduino.h>
+
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <cstdlib>
 
 #include "config.h"
@@ -15,7 +18,7 @@
 #include "ui/radar_theme.h"
 #include "ui/runway_overlay.h"
 
-namespace fonts = lgfx::v1::fonts;
+namespace lgfx_fonts = lgfx::v1::fonts;
 
 namespace ui {
 namespace radar {
@@ -30,6 +33,7 @@ uint16_t kColorTagType = 0x5DFF;
 uint16_t kColorTagAltitude = 0xFFE0;
 uint16_t kColorRunway = 0x4D5F;
 uint16_t kColorRunwayLabel = 0x7DFF;
+uint16_t kColorInfoMuted = 0xC618;
 
 }  // namespace radar
 
@@ -41,12 +45,13 @@ bool s_scale_use_vlw = false;
 float s_cardinal_vlw_size = 0.56f;
 float s_scale_vlw_size = 0.50f;
 float s_tag_vlw_size = 0.56f;
-const lgfx::GFXfont* s_cardinal_gfx = &fonts::FreeSansBold12pt7b;
-const lgfx::GFXfont* s_scale_gfx = &fonts::FreeSansBold9pt7b;
-const lgfx::GFXfont* s_tag_gfx = &fonts::FreeSansBold12pt7b;
+const lgfx::GFXfont* s_cardinal_gfx = &lgfx_fonts::FreeSansBold12pt7b;
+const lgfx::GFXfont* s_scale_gfx = &lgfx_fonts::FreeSansBold9pt7b;
+const lgfx::GFXfont* s_tag_gfx = &lgfx_fonts::FreeSansBold12pt7b;
 
 bool s_tag_label_metrics_ready = false;
 bool s_tag_use_vlw = false;
+unsigned long s_last_adsb_update_ms = 0;
 
 int s_scale_label_max_w = 0;
 int s_scale_label_h = 0;
@@ -123,16 +128,16 @@ void initLabelMetrics() {
     s_scale_use_vlw = true;
     s_scale_vlw_size = findVlwSizeForHeight(scale_target);
   } else {
-    const lgfx::GFXfont* cardinal_candidates[] = {&fonts::FreeSansBold12pt7b,
-                                                  &fonts::FreeSansBold9pt7b};
+    const lgfx::GFXfont* cardinal_candidates[] = {&lgfx_fonts::FreeSansBold12pt7b,
+                                                  &lgfx_fonts::FreeSansBold9pt7b};
     s_cardinal_gfx =
         pickGfxFontClosest(cardinal_target, cardinal_candidates, 2);
     s_cardinal_use_vlw = false;
 
     const int cardinal_h = measureGfxHeight(*s_cardinal_gfx);
     const int scale_target = cardinal_h - radar::kScaleBelowCardinalPx;
-    const lgfx::GFXfont* scale_candidates[] = {&fonts::FreeSansBold9pt7b,
-                                               &fonts::FreeSansBold12pt7b};
+    const lgfx::GFXfont* scale_candidates[] = {&lgfx_fonts::FreeSansBold9pt7b,
+                                               &lgfx_fonts::FreeSansBold12pt7b};
     s_scale_gfx = pickGfxFontClosest(scale_target, scale_candidates, 2);
     s_scale_use_vlw = false;
   }
@@ -165,8 +170,8 @@ void initTagLabelMetrics() {
     s_tag_use_vlw = true;
     s_tag_vlw_size = findVlwSizeForHeight(target);
   } else {
-    const lgfx::GFXfont* tag_candidates[] = {&fonts::FreeSansBold12pt7b,
-                                               &fonts::FreeSansBold9pt7b};
+    const lgfx::GFXfont* tag_candidates[] = {&lgfx_fonts::FreeSansBold12pt7b,
+                                               &lgfx_fonts::FreeSansBold9pt7b};
     s_tag_gfx = pickGfxFontClosest(target, tag_candidates, 2);
     s_tag_use_vlw = false;
   }
@@ -655,6 +660,165 @@ void drawStaticGrid(Gfx& gfx) {
   gfx.setTextDatum(textdatum_t::top_left);
 }
 
+const char* bearingLabel(float dx_km, float dy_km) {
+  constexpr const char* kLabels[] = {"N", "NE", "E", "SE",
+                                       "S", "SW", "W", "NW"};
+  float deg = atan2f(dx_km, dy_km) * 57.2957795f;
+  if (deg < 0.0f) {
+    deg += 360.0f;
+  }
+  const int sector = static_cast<int>((deg + 22.5f) / 45.0f) & 7;
+  return kLabels[sector];
+}
+
+struct NearestAircraftInfo {
+  const services::adsb::Aircraft* aircraft = nullptr;
+  float km = 0.0f;
+  const char* bearing = "";
+};
+
+size_t findNearestAircraft(NearestAircraftInfo* nearest, size_t max_count) {
+  const size_t count = services::adsb::aircraftCount();
+  const services::adsb::Aircraft* planes = services::adsb::aircraftList();
+  size_t found = 0;
+
+  for (size_t i = 0; i < count; ++i) {
+    float dx_km = 0.0f;
+    float dy_km = 0.0f;
+    float dist_km = 0.0f;
+    offsetKmFromCenter(planes[i].lat, planes[i].lon, &dx_km, &dy_km, &dist_km);
+    if (dist_km <= 0.0f) {
+      continue;
+    }
+
+    if (found == max_count && dist_km >= nearest[found - 1].km) {
+      continue;
+    }
+
+    size_t insert_at = found < max_count ? found : max_count - 1;
+    while (insert_at > 0 && dist_km < nearest[insert_at - 1].km) {
+      nearest[insert_at] = nearest[insert_at - 1];
+      --insert_at;
+    }
+
+    nearest[insert_at].aircraft = &planes[i];
+    nearest[insert_at].km = dist_km;
+    nearest[insert_at].bearing = bearingLabel(dx_km, dy_km);
+    if (found < max_count) {
+      ++found;
+    }
+  }
+
+  return found;
+}
+
+void formatDistance(char* out, size_t out_len, float km) {
+  if (radar::useMiles()) {
+    snprintf(out, out_len, "%.1fmi", km / 1.609344f);
+    return;
+  }
+  snprintf(out, out_len, "%.1fkm", km);
+}
+
+void drawInfoPanel() {
+  if (!config::kRadarInfoPanelEnabled) {
+    return;
+  }
+
+  displayFontEnsureLoaded(*s_draw);
+
+  constexpr int card_w = 228;
+  constexpr int card_h = 70;
+  const int card_x = (config::kDisplayWidth - card_w) / 2;
+  const int card_y = config::kDisplayHeight - card_h - 2;
+  constexpr int pad_x = 8;
+  constexpr int pad_y = 7;
+  constexpr int label_gap = 17;
+
+  s_draw->fillRoundRect(card_x, card_y, card_w, card_h, 7,
+                        radar::kColorBackground);
+  s_draw->drawRoundRect(card_x, card_y, card_w, card_h, 7,
+                        radar::kColorGrid);
+
+  char range_label[12];
+  radar::formatCurrentRing3Label(range_label, sizeof(range_label));
+
+  char updated_label[16];
+  if (s_last_adsb_update_ms == 0) {
+    snprintf(updated_label, sizeof(updated_label), "--");
+  } else {
+    unsigned long age_s = (millis() - s_last_adsb_update_ms) / 1000UL;
+    if (age_s == 0) {
+      age_s = 1;
+    }
+    snprintf(updated_label, sizeof(updated_label), "%lus", age_s);
+  }
+
+  const int col_w = (card_w - pad_x * 2) / 3;
+  const int col_y = card_y + pad_y;
+  const int value_y = col_y + label_gap;
+  const int col0 = card_x + pad_x + col_w / 2;
+  const int col1 = col0 + col_w;
+  const int col2 = col1 + col_w;
+
+  s_draw->setTextDatum(textdatum_t::top_center);
+  s_draw->setTextColor(radar::kColorGrid, radar::kColorBackground);
+  s_draw->drawString("RANGE", col0, col_y);
+  s_draw->drawString("ACFT", col1, col_y);
+  s_draw->drawString("AGE", col2, col_y);
+
+  s_draw->setTextColor(radar::kColorLabel, radar::kColorBackground);
+  s_draw->drawString(range_label, col0, value_y);
+
+  char aircraft_label[8];
+  snprintf(aircraft_label, sizeof(aircraft_label), "%u",
+           static_cast<unsigned>(services::adsb::aircraftCount()));
+  s_draw->setTextColor(radar::kColorAircraft, radar::kColorBackground);
+  s_draw->drawString(aircraft_label, col1, value_y);
+
+  s_draw->setTextColor(radar::kColorInfoMuted, radar::kColorBackground);
+  s_draw->drawString(updated_label, col2, value_y);
+
+  NearestAircraftInfo nearest[1];
+  const size_t nearest_count = findNearestAircraft(nearest, 1);
+  const int text_x = card_x + pad_x;
+  const int nearest_y = card_y + 46;
+
+  s_draw->setTextDatum(textdatum_t::top_left);
+  if (nearest_count == 0) {
+    s_draw->setTextColor(radar::kColorGrid, radar::kColorBackground);
+    s_draw->drawString("NEAREST", text_x, nearest_y);
+    s_draw->setTextColor(radar::kColorLabel, radar::kColorBackground);
+    s_draw->drawString("none", text_x + 64, nearest_y);
+    return;
+  }
+
+  const services::adsb::Aircraft* aircraft = nearest[0].aircraft;
+  char dist_label[16];
+  formatDistance(dist_label, sizeof(dist_label), nearest[0].km);
+  const char* ident =
+      aircraft->callsign[0] != '\0' ? aircraft->callsign : "unknown";
+  const char* type = aircraft->type[0] != '\0' ? aircraft->type : "--";
+  const char* alt = aircraft->alt[0] != '\0' ? aircraft->alt : "--";
+  int cursor_x = text_x;
+  s_draw->setTextColor(radar::kColorLabel, radar::kColorBackground);
+  s_draw->drawString(ident, cursor_x, nearest_y);
+  cursor_x += s_draw->textWidth(ident) + 6;
+
+  s_draw->setTextColor(radar::kColorTagType, radar::kColorBackground);
+  s_draw->drawString(type, cursor_x, nearest_y);
+  cursor_x += s_draw->textWidth(type) + 6;
+
+  char line[32];
+  snprintf(line, sizeof(line), "%s %s", dist_label, nearest[0].bearing);
+  s_draw->setTextColor(radar::kColorLabel, radar::kColorBackground);
+  s_draw->drawString(line, cursor_x, nearest_y);
+  cursor_x += s_draw->textWidth(line) + 6;
+
+  s_draw->setTextColor(radar::kColorTagAltitude, radar::kColorBackground);
+  s_draw->drawString(alt, cursor_x, nearest_y);
+}
+
 bool ensureFrameSprite() {
   if (s_frame_ready) {
     return true;
@@ -676,6 +840,7 @@ void renderFrame() {
   {
     const DrawScope scope(s_frame);
     drawAircraft();
+    drawInfoPanel();
   }
   s_frame.pushSprite(0, 0);
   tft.setTextDatum(textdatum_t::top_left);
@@ -697,10 +862,12 @@ void radarDisplayDraw() {
   const DrawScope scope(tft);
   drawStaticGrid(tft);
   drawAircraft();
+  drawInfoPanel();
   tft.setTextDatum(textdatum_t::top_left);
 }
 
 void radarDisplayRefreshAircraft() {
+  s_last_adsb_update_ms = millis();
   initPalette();
 
   if (ensureFrameSprite()) {
@@ -709,6 +876,25 @@ void radarDisplayRefreshAircraft() {
   }
 
   radarDisplayDraw();
+}
+
+void radarDisplayRefreshInfo() {
+  if (!config::kRadarInfoPanelEnabled) {
+    return;
+  }
+
+  initPalette();
+  if (ensureFrameSprite()) {
+    const DrawScope scope(s_frame);
+    drawInfoPanel();
+    s_frame.pushSprite(0, 0);
+    tft.setTextDatum(textdatum_t::top_left);
+    return;
+  }
+
+  const DrawScope scope(tft);
+  drawInfoPanel();
+  tft.setTextDatum(textdatum_t::top_left);
 }
 
 }  // namespace ui

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -11,7 +11,7 @@
 #include "ui/radar_range.h"
 #include "ui/radar_theme.h"
 
-namespace fonts = lgfx::v1::fonts;
+namespace lgfx_fonts = lgfx::v1::fonts;
 
 namespace ui::runway {
 namespace {
@@ -25,7 +25,7 @@ bool s_label_pending[data::large_airports::kAirportCount];
 bool s_runway_label_ready = false;
 bool s_runway_label_use_vlw = false;
 float s_runway_label_vlw_size = 0.38f;
-const lgfx::GFXfont* s_runway_label_gfx = &fonts::FreeSansBold12pt7b;
+const lgfx::GFXfont* s_runway_label_gfx = &lgfx_fonts::FreeSansBold12pt7b;
 
 int measureVlwHeight(lgfx::LGFXBase& gfx, float size) {
   gfx.setTextSize(size);
@@ -56,7 +56,7 @@ void initRunwayLabelStyle(lgfx::LGFXBase& gfx) {
     s_runway_label_use_vlw = true;
     s_runway_label_vlw_size = findVlwSizeForHeight(gfx, target);
   } else {
-    s_runway_label_gfx = &fonts::FreeSansBold12pt7b;
+    s_runway_label_gfx = &lgfx_fonts::FreeSansBold12pt7b;
     s_runway_label_use_vlw = false;
   }
   s_runway_label_ready = true;

--- a/src/ui/status_screens.cpp
+++ b/src/ui/status_screens.cpp
@@ -11,7 +11,7 @@
 #include "hardware/display.h"
 #include "hardware/display_font.h"
 
-namespace fonts = lgfx::v1::fonts;
+namespace lgfx_fonts = lgfx::v1::fonts;
 
 namespace {
 
@@ -38,13 +38,13 @@ float s_spinner_angle_deg = -90.0f;
 SpinnerDot s_spinner_dots[kSpinnerDotCount];
 bool s_connecting_text_drawn = false;
 
-constexpr auto& kGfxTitle = fonts::FreeSans18pt7b;
-constexpr auto& kGfxBody = fonts::FreeSans12pt7b;
-constexpr auto& kGfxDetail = fonts::Font2;
-constexpr auto& kPortalGfxTitle = fonts::FreeSansBold18pt7b;
-constexpr auto& kPortalGfxBody = fonts::FreeSansBold12pt7b;
-constexpr auto& kPortalGfxEmphasis = fonts::FreeSansBold18pt7b;
-constexpr auto& kConnectingGfxDetail = fonts::FreeSans9pt7b;
+constexpr auto& kGfxTitle = lgfx_fonts::FreeSans18pt7b;
+constexpr auto& kGfxBody = lgfx_fonts::FreeSans12pt7b;
+constexpr auto& kGfxDetail = lgfx_fonts::Font2;
+constexpr auto& kPortalGfxTitle = lgfx_fonts::FreeSansBold18pt7b;
+constexpr auto& kPortalGfxBody = lgfx_fonts::FreeSansBold12pt7b;
+constexpr auto& kPortalGfxEmphasis = lgfx_fonts::FreeSansBold18pt7b;
+constexpr auto& kConnectingGfxDetail = lgfx_fonts::FreeSans9pt7b;
 
 struct TextLine {
   const char* text;


### PR DESCRIPTION
# PR Title

Add support for OpenNextion ONX2432G028

## Summary

This PR adds a first-pass board target for the OpenNextion ONX2432G028 ESP32-S3 display board while keeping the original Plane Radar UI behavior intact.

The ONX2432G028 has a 2.8 inch 240x320 ST7789 SPI display, so this implementation keeps the original 240x240 circular radar view and centers it on the rectangular panel. This avoids redesigning the radar UI in the initial board-support PR.

## Changes

- Add a custom PlatformIO board definition for `onx2432g028`.
- Add a PlatformIO environment for `onx2432g028`.
- Add conditional display configuration for the ONX2432G028 ST7789 panel.
- Add minimal ONX board initialization for I2C, PCF8574, LCD reset, SDCS release, and LCD backlight.
- Keep the original circular radar UI centered in a 240x240 viewport on the 240x320 screen.
- Keep the existing BOOT button behavior:
  - short press cycles the radar range
  - long press clears Wi-Fi/location/unit settings and reboots into setup

## Build / Flash

This PR intentionally leaves the public README unchanged. If this board target is accepted, the maintainer can decide whether and how to expose it in the README.

Build the ONX2432G028 firmware with:

```bash
pio run -e onx2432g028
```

Flash it with:

```bash
pio run -e onx2432g028 -t upload --upload-port <PORT>
```

Create a merged image with:

```bash
pio run -e onx2432g028 -t merge
```

## Hardware

| Item | Value |
| --- | --- |
| Board | OpenNextion ONX2432G028 |
| MCU | ESP32-S3R8 |
| Flash | 16 MB |
| PSRAM | 8 MB OPI PSRAM |
| Display | 2.8 inch ST7789 SPI TFT |
| Resolution | 240x320 |
| Touch controller | CST826, not used in this PR |
| I/O expander | PCF8574 at `0x38` |
| LCD reset | PCF8574 EXIO6 |
| LCD backlight | GPIO6 |
| LCD SCLK | GPIO5 |
| LCD MOSI | GPIO1 |
| LCD CS | GPIO2 |
| LCD DC | GPIO3 |
| BOOT button | GPIO0 |

## Validation

- [x] Builds with `pio run -e onx2432g028`
- [x] Flashes successfully on ONX2432G028 hardware
- [x] Device boots without panic, watchdog reset, or reboot loop
- [x] LCD displays the radar UI correctly
- [x] Wi-Fi setup flow works
- [x] Radar view displays and updates with ADS-B fetch logs
- [x] ADS-B fetch can return aircraft, for example `adsb: 1 aircraft` and `adsb: 2 aircraft`
- [x] BOOT short press range cycling verified
- [x] BOOT long press Wi-Fi reset verified
- [x] Photo or screenshot attached
- [x] Serial boot log attached

## Notes

- This PR intentionally does not add a new rectangular-screen UI layout or bottom status bar.
- This PR does not add touch input support yet.
- This PR does not add SD card support yet.
- The board exposes a CST826 touch controller, but the original project currently uses the BOOT button for range/reset input.

## Logs / Screenshots

Serial boot log:

```
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x1 (POWERON),boot:0x9 (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce3808,len:0x44c
load:0x403c9700,len:0xbd8
load:0x403cc700,len:0x2a80
entry 0x403c98d0

Plane Radar
Connecting to WiFi (portal opens if needed)...
Connected: fangxiao_CH2_vpn  IP 192.168.1.190
LAN config: http://plane-radar.local or http://192.168.1.190
adsb: 1 aircraft
adsb: 1 aircraft
adsb: 1 aircraft

```

Radar screen photo:

<img width="961" height="1280" alt="main" src="https://github.com/user-attachments/assets/dc7155a7-0398-4728-9e42-20ead4b85c48" />

Wi-Fi setup photo:

<img width="961" height="1280" alt="init" src="https://github.com/user-attachments/assets/2642250c-8a8d-4509-ba32-a5fe748cdbc4" />
<img width="591" height="1280" alt="wifi_manager" src="https://github.com/user-attachments/assets/cc981611-9029-4b3c-a2d6-d7aa7511a00e" />
<img width="591" height="1280" alt="wifi_list" src="https://github.com/user-attachments/assets/fa909874-c0b2-4966-ad12-6fe5b2533b67" />


BOOT short press range log:

```
adsb: 0 aircraft
Range: 15km (outer ~20 km)
adsb: 1 aircraft
adsb: 0 aircraft
Range: 25km (outer ~33 km)
Range: 5km (outer ~7 km)
adsb: 0 aircraft
Range: 10km (outer ~13 km)
Range: 15km (outer ~20 km)
adsb: 0 aircraft
Range: 25km (outer ~33 km)

```

BOOT long press reset log:

```
BOOT held — resetting WiFi
WiFi credentials, location, and units cleared
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0xc (RTC_SW_CPU_RST),boot:0x9 (SPI_FAST_FLASH_BOOT)
Saved PC:0x420bf04e
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce3808,len:0x44c
load:0x403c9700,len:0xbd8
load:0x403cc700,len:0x2a80
entry 0x403c98d0

Plane Radar
Opening WiFi setup portal (after reset)
Setup portal: http://plane-radar.local (or http://192.168.4.1)

```
