### PR TITLE
Make mDNS hostname configurable via Wi-Fi setup portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ During setup you can also hold BOOT at power-on to force a credential reset (sam
 **Reconfigure anytime** (after the device is on your network):
 
 1. Open **`http://plane-radar.local`** or **`http://<device-ip>`** (e.g. from your router or serial log at boot)
-2. Change Wi‑Fi, location, units, or runway overlay; save
+2. Change Wi‑Fi, location, units, runway overlay, or device name; save
 
-The same portal runs on the setup AP and on the device’s LAN IP while connected to Wi‑Fi. mDNS hostname is `plane-radar` → **plane-radar.local** (`kPortalHostname` in `config.h`). Some clients resolve `.local` slowly; use the IP if needed.
+The same portal runs on the setup AP and on the device’s LAN IP while connected to Wi‑Fi. mDNS hostname defaults to `plane-radar` → **plane-radar.local**, but can be changed from the portal's "Device name" field (persisted in NVS; falls back to `kPortalHostname` in `config.h` if never set, and resets to it on a WiFi credential reset). Some clients resolve `.local` slowly; use the IP if needed.
 
 **Custom fields** (stored in NVS):
 
@@ -95,11 +95,12 @@ Edit **`include/config.h`** for hardware and behavior:
 
 | Area | Keys / notes |
 |------|----------------|
-| Portal | `kPortalApName`, `kPortalIp`, `kPortalHostname` / `kPortalHostUrl` (mDNS; needs `-DWM_MDNS` in `platformio.ini`) |
+| Portal | `kPortalApName`, `kPortalIp`, `kPortalHostname` (mDNS default; needs `-DWM_MDNS` in `platformio.ini`) |
 | Wi‑Fi timing | connect attempts, reconnect grace, portal timeout (`0` = no timeout) |
 | BOOT | `kBootPin`, `kBootResetHoldMs`, `kBootTapMinMs` |
 | Display SPI | pins, `kDisplayInvert`, `kDisplayRgbOrder`, `kDisplaySpiWriteHz` |
 | Default location | `kDefaultRadarLat`, `kDefaultRadarLon` (until portal overrides) |
+| Device name | mDNS hostname override, set via portal "Device name" field (until portal overrides) |
 | ADS-B | `kAdsbFetchIntervalMs`, `kAdsbShowGroundAircraft` |
 
 Range presets: `include/ui/radar_range.h` (`kRangePresets`).

--- a/include/config.h
+++ b/include/config.h
@@ -9,9 +9,8 @@ namespace config {
 // --- Wi-Fi portal ---
 constexpr char kPortalApName[] = "PlaneRadar-Setup";
 constexpr char kPortalIp[] = "192.168.4.1";
-/** mDNS host (no ".local" suffix); browser: http://plane-radar.local */
+/** Default mDNS host (no ".local" suffix) if nothing saved in NVS; browser: http://plane-radar.local */
 constexpr char kPortalHostname[] = "plane-radar";
-constexpr char kPortalHostUrl[] = "plane-radar.local";
 
 /** Per-attempt STA connect wait (ms); retried kWifiConnectAttempts times. */
 constexpr unsigned long kWifiConnectAttemptMs = 15000;

--- a/include/services/hostname.h
+++ b/include/services/hostname.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace services::hostname {
+
+/** Load saved hostname from NVS, or use config default. Call once before WiFi setup. */
+void init();
+
+/** Bare mDNS label (no ".local"), for MDNS.begin()/setHostname(). */
+const char* value();
+
+/** "<value>.local", for on-screen/log display. */
+const char* hostUrl();
+
+/** Validate, persist to NVS, and update runtime values. False (unchanged) if invalid. */
+bool saveFromString(const char* hostname);
+
+/** Reset to the compiled default (e.g. with WiFi credential reset). */
+void clear();
+
+}  // namespace services::hostname

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "config.h"
 #include "hardware/display.h"
 #include "services/adsb_client.h"
+#include "services/hostname.h"
 #include "services/radar_location.h"
 #include "services/wifi_setup.h"
 #include "ui/radar_display.h"
@@ -70,6 +71,7 @@ void setup() {
 
   bootButtonInit();
   displayInit();
+  services::hostname::init();
   if (wifiShowsSetupScreenOnBoot()) {
     statusScreenPortal();
   }

--- a/src/services/hostname.cpp
+++ b/src/services/hostname.cpp
@@ -1,0 +1,94 @@
+#include "services/hostname.h"
+
+#include <Preferences.h>
+#include <cstdio>
+#include <cstring>
+
+#include "config.h"
+
+namespace services::hostname {
+
+namespace {
+
+constexpr char kPrefsNamespace[] = "hostname";
+constexpr char kKeyHost[] = "host";
+constexpr size_t kMaxLen = 32;
+
+char s_hostname[kMaxLen + 1];
+char s_host_url[kMaxLen + 1 + 6];  // + ".local"
+
+void updateHostUrl() {
+  snprintf(s_host_url, sizeof(s_host_url), "%s.local", s_hostname);
+}
+
+void setRuntimeValue(const char* hostname) {
+  strncpy(s_hostname, hostname, kMaxLen);
+  s_hostname[kMaxLen] = '\0';
+  updateHostUrl();
+}
+
+bool validHostname(const char* text) {
+  const size_t len = text != nullptr ? strlen(text) : 0;
+  if (len == 0 || len > kMaxLen) {
+    return false;
+  }
+  if (text[0] == '-' || text[len - 1] == '-') {
+    return false;
+  }
+  for (size_t i = 0; i < len; ++i) {
+    const char c = text[i];
+    const bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                    (c >= '0' && c <= '9') || c == '-';
+    if (!ok) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void persist(const char* hostname) {
+  Preferences prefs;
+  prefs.begin(kPrefsNamespace, false);
+  prefs.putString(kKeyHost, hostname);
+  prefs.end();
+  setRuntimeValue(hostname);
+}
+
+}  // namespace
+
+void init() {
+  setRuntimeValue(config::kPortalHostname);
+  Preferences prefs;
+  prefs.begin(kPrefsNamespace, true);
+  if (prefs.isKey(kKeyHost)) {
+    char stored[kMaxLen + 1];
+    prefs.getString(kKeyHost, stored, sizeof(stored));
+    if (validHostname(stored)) {
+      setRuntimeValue(stored);
+    }
+  }
+  prefs.end();
+}
+
+const char* value() { return s_hostname; }
+
+const char* hostUrl() { return s_host_url; }
+
+bool saveFromString(const char* hostname) {
+  if (!validHostname(hostname)) {
+    return false;
+  }
+  persist(hostname);
+  Serial.printf("mDNS hostname saved: %s\n", s_hostname);
+  return true;
+}
+
+void clear() {
+  Preferences prefs;
+  prefs.begin(kPrefsNamespace, false);
+  prefs.remove(kKeyHost);
+  prefs.end();
+  setRuntimeValue(config::kPortalHostname);
+}
+
+}  // namespace services::hostname

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include "config.h"
+#include "services/hostname.h"
 #include "services/radar_location.h"
 #include "ui/radar_range.h"
 #include "ui/status_screens.h"
@@ -84,6 +85,15 @@ char s_runways_checkbox_attrs[32] = "type=\"checkbox\"";
 WiFiManagerParameter s_param_runways("show_runways", "Show airport runways", "T", 2,
                                      s_runways_checkbox_attrs, WFM_LABEL_AFTER);
 
+WiFiManagerParameter s_param_hostname_sep("<hr/>");
+
+constexpr int kHostnameParamLen = 32;
+constexpr char kHostnameInputAttrs[] =
+    " maxlength=\"32\" pattern=\"[A-Za-z0-9-]{1,32}\"";
+
+WiFiManagerParameter s_param_hostname("mdns_host", "Device name (mDNS: <name>.local)", "",
+                                      kHostnameParamLen, kHostnameInputAttrs);
+
 void refreshPortalParamDefaults() {
   char lat_buf[kCoordParamLen + 1];
   char lon_buf[kCoordParamLen + 1];
@@ -97,6 +107,7 @@ void refreshPortalParamDefaults() {
   snprintf(s_runways_checkbox_attrs, sizeof(s_runways_checkbox_attrs),
            "type=\"checkbox\"%s", ui::radar::showRunways() ? " checked" : "");
   s_param_runways.setValue("T", 2);
+  s_param_hostname.setValue(services::hostname::value(), kHostnameParamLen);
 }
 
 void onPortalParamsSaved() {
@@ -106,6 +117,17 @@ void onPortalParamsSaved() {
   }
   ui::radar::saveMilesFromPortal(s_param_miles.getValue());
   ui::radar::saveRunwaysFromPortal(s_param_runways.getValue());
+
+  if (!services::hostname::saveFromString(s_param_hostname.getValue())) {
+    Serial.println("Invalid hostname in portal — keeping previous");
+  } else {
+#ifdef WM_MDNS
+    MDNS.end();
+    if (MDNS.begin(services::hostname::value())) {
+      MDNS.addService("http", "tcp", 80);
+    }
+#endif
+  }
 }
 
 void attachPortalParams(WiFiManager& wm) {
@@ -114,6 +136,8 @@ void attachPortalParams(WiFiManager& wm) {
   wm.addParameter(&s_param_lon);
   wm.addParameter(&s_param_miles);
   wm.addParameter(&s_param_runways);
+  wm.addParameter(&s_param_hostname_sep);
+  wm.addParameter(&s_param_hostname);
   wm.setSaveParamsCallback(onPortalParamsSaved);
 }
 
@@ -191,16 +215,17 @@ void resetWifiCredentials() {
   eraseWifiCredentials();
   services::location::clear();
   ui::radar::unitsReset();
-  Serial.println("WiFi credentials, location, and units cleared");
+  services::hostname::clear();
+  Serial.println("WiFi credentials, location, units, and hostname cleared");
 }
 
 void onConfigPortalApStarted(WiFiManager*) {
   statusScreenPortal();
 #ifdef WM_MDNS
-  if (MDNS.begin(config::kPortalHostname)) {
+  if (MDNS.begin(services::hostname::value())) {
     MDNS.addService("http", "tcp", 80);
     Serial.printf("Setup portal: http://%s.local (or http://%s)\n",
-                  config::kPortalHostname, config::kPortalIp);
+                  services::hostname::value(), config::kPortalIp);
   } else {
     Serial.printf("Setup portal: http://%s (mDNS unavailable)\n", config::kPortalIp);
   }
@@ -221,7 +246,7 @@ void ensureWifiManager() {
   s_wm.setConfigPortalTimeout(config::kWifiPortalTimeoutSec);
   s_wm.setAPStaticIPConfig(IPAddress(192, 168, 4, 1), IPAddress(192, 168, 4, 1),
                            IPAddress(255, 255, 255, 0));
-  s_wm.setHostname(config::kPortalHostname);
+  s_wm.setHostname(services::hostname::value());
   s_wm.setAPCallback(onConfigPortalApStarted);
   attachPortalParams(s_wm);
   s_wm_configured = true;
@@ -237,13 +262,13 @@ void startLanWebPortal() {
   s_wm.setConfigPortalBlocking(false);
 #ifdef WM_MDNS
   MDNS.end();
-  if (MDNS.begin(config::kPortalHostname)) {
+  if (MDNS.begin(services::hostname::value())) {
     MDNS.addService("http", "tcp", 80);
   }
 #endif
   s_wm.startWebPortal();
   Serial.printf("LAN config: http://%s.local or http://%s\n",
-                config::kPortalHostname, WiFi.localIP().toString().c_str());
+                services::hostname::value(), WiFi.localIP().toString().c_str());
 }
 
 void stopLanWebPortal() {

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -15,8 +15,6 @@
 #include "ui/radar_theme.h"
 #include "ui/runway_overlay.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui {
 namespace radar {
 

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -11,8 +11,6 @@
 #include "ui/radar_range.h"
 #include "ui/radar_theme.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui::runway {
 namespace {
 

--- a/src/ui/status_screens.cpp
+++ b/src/ui/status_screens.cpp
@@ -10,8 +10,7 @@
 #include "config.h"
 #include "hardware/display.h"
 #include "hardware/display_font.h"
-
-namespace fonts = lgfx::v1::fonts;
+#include "services/hostname.h"
 
 namespace {
 
@@ -214,7 +213,7 @@ void statusScreenPortal() {
       {"1. Join network:", 1.05f, &kPortalGfxBody},
       {config::kPortalApName, 1.12f, &kPortalGfxEmphasis},
       {"2. Open in browser:", 1.05f, &kPortalGfxBody},
-      {config::kPortalHostUrl, 1.12f, &kPortalGfxEmphasis},
+      {services::hostname::hostUrl(), 1.12f, &kPortalGfxEmphasis},
       {"or 192.168.4.1", 1.0f, &kPortalGfxBody},
   };
   drawTextBlock(config::kColorYellow, config::kTextOnYellow, lines,


### PR DESCRIPTION
## Summary
- Adds a "Device name" text field to the Wi-Fi setup/config portal so the mDNS hostname (`plane-radar.local` by default) can be changed without recompiling firmware.
- New `services::hostname` module mirrors the existing radar-location pattern: persists the value in NVS, validates it (DNS-safe characters, 1-32 length, no leading/trailing hyphen), and exposes the runtime value/URL to the rest of the firmware.
- Saving the field in the portal restarts mDNS immediately so the new `<name>.local` address is reachable without a reboot.
- A Wi-Fi credential factory reset (BOOT long-press) also resets the hostname back to the compiled default.
- Fixes an unrelated build break: the `LovyanGFX` dependency (pinned `^1.2.7`) now resolves to `1.2.24`, which ships its own global `fonts` namespace that conflicted with a redundant local alias declared in three UI files (`radar_display.cpp`, `runway_overlay.cpp`, `status_screens.cpp`). Removed the now-redundant aliases so the project builds clean from a fresh dependency install.

## Test plan
- [x] `pio run -e supermini` builds successfully
- [x] `pio run -e supermini -t merge` produces a flashable `firmware-merged.bin`
- [ ] Flash to hardware and confirm the setup screen shows `plane-radar.local` by default
- [ ] Set a custom hostname via the portal, confirm the setup screen updates and `http://<name>.local` resolves without a reboot
- [ ] Confirm the custom hostname survives a normal reboot (NVS persistence)
- [ ] Long-press BOOT to factory reset, confirm hostname reverts to `plane-radar.local` along with Wi-Fi/location/units
- [ ] Confirm invalid input (empty, spaces, leading hyphen) is rejected and the previous hostname is retained