### PR TITLE
Pin LovyanGFX to 1.2.21 to fix build failure on fresh installs

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,8 @@ build_flags =
   -DWM_MDNS
 
 lib_deps =
-  lovyan03/LovyanGFX@^1.2.7
+  ; pinned: 1.2.24+ declares its own `fonts` alias that collides with the
+  ; one used here, and 1.2.7 predates the two-arg loadFont() this code uses
+  lovyan03/LovyanGFX@1.2.21
   tzapu/WiFiManager@^2.0.17
   bblanchon/ArduinoJson@^7.4.2


### PR DESCRIPTION
The `lovyan03/LovyanGFX@^1.2.7` constraint in `platformio.ini` currently resolves to 1.2.24 (published 2026-06-24), which declares its own `fonts` namespace alias that collides with this project's `namespace fonts = lgfx::v1::fonts;` alias in `radar_display.cpp`, `runway_overlay.cpp`, and `status_screens.cpp` — three compile errors on any fresh clone or CI cache miss. The exact 1.2.7 floor also fails to build, since it predates the two-argument `loadFont()` used in `display_font.cpp`, so the safe range is narrower than the current constraint implies.

Pinning to `1.2.21` — the newest version confirmed to build cleanly against this code — stops the build from depending on a stale library cache to stay green. (Note: `pio pkg install` re-resolves floating ranges against the registry even with a matching cached version, which is why the cache workaround is fragile.)

This pin has been running in a fork of this project in daily use with no issues. Thanks for a great project!

🤖 Generated with [Claude Code](https://claude.com/claude-code)