### PR TITLE
Correct east-west distances for latitude (cos(lat) scaling)

### DIFF
--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -200,11 +200,16 @@ void initPalette() {
 }
 
 constexpr float kKmPerDeg = 111.0f;
+constexpr float kDegToRad = 3.14159265f / 180.0f;
 
 void offsetKmFromCenter(float lat, float lon, float* dx_km, float* dy_km,
                         float* dist_km) {
-  *dx_km =
-      static_cast<float>(lon - services::location::lon()) * kKmPerDeg;
+  // Longitude degrees shrink toward the poles; scale by cos(latitude) so
+  // east-west distance isn't overstated away from the equator.
+  const float center_lat_rad =
+      static_cast<float>(services::location::lat()) * kDegToRad;
+  *dx_km = static_cast<float>(lon - services::location::lon()) * kKmPerDeg *
+           cosf(center_lat_rad);
   *dy_km =
       static_cast<float>(lat - services::location::lat()) * kKmPerDeg;
   *dist_km = sqrtf((*dx_km) * (*dx_km) + (*dy_km) * (*dy_km));

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -17,6 +17,7 @@ namespace ui::runway {
 namespace {
 
 constexpr float kKmPerDeg = 111.0f;
+constexpr float kDegToRad = 3.14159265f / 180.0f;
 constexpr size_t kMaxAirportLabels = 32;
 
 bool s_in_range[data::large_airports::kAirportCount];
@@ -74,8 +75,12 @@ float e7ToDeg(int32_t e7) { return static_cast<float>(e7) * 1e-7f; }
 
 void offsetKmFromCenter(float lat, float lon, float* dx_km, float* dy_km,
                         float* dist_km) {
-  *dx_km =
-      static_cast<float>(lon - services::location::lon()) * kKmPerDeg;
+  // Longitude degrees shrink toward the poles; scale by cos(latitude) so
+  // east-west distance isn't overstated away from the equator.
+  const float center_lat_rad =
+      static_cast<float>(services::location::lat()) * kDegToRad;
+  *dx_km = static_cast<float>(lon - services::location::lon()) * kKmPerDeg *
+           cosf(center_lat_rad);
   *dy_km =
       static_cast<float>(lat - services::location::lat()) * kKmPerDeg;
   *dist_km = sqrtf((*dx_km) * (*dx_km) + (*dy_km) * (*dy_km));


### PR DESCRIPTION
`offsetKmFromCenter()` in both `radar_display.cpp` and `runway_overlay.cpp` converts the longitude delta to kilometers with the same flat `111 km/deg` factor as latitude, which is only accurate at the equator — a degree of longitude shrinks by `cos(latitude)` toward the poles. This overstates all east-west screen positions and distances (aircraft and runways): ~19% at 36°N, and ~38% at this project's own default center (Amsterdam, ~52.37°N).

The fix scales the longitude term by `cosf(center latitude)` in both files' `offsetKmFromCenter`; no shared header is introduced, keeping the diff trivially reviewable. Sanity check: 1° of longitude at 52.37°N should be ~67.8 km (111 × cos 52.37°), which the corrected formula reproduces.

Heads-up: aircraft will render slightly closer east-west after this change — that's the correction, not a regression. This fix has been running in a fork of this project in daily use with no issues.

(Builds against LovyanGFX 1.2.21; see #49 for why fresh installs currently need that pin.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)