### PR TITLE
Remove duplicate fonts namespace alias

### DIFF
--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -15,7 +15,6 @@
 #include "ui/radar_theme.h"
 #include "ui/runway_overlay.h"
 
-namespace fonts = lgfx::v1::fonts;
 
 namespace ui {
 namespace radar {

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -11,7 +11,6 @@
 #include "ui/radar_range.h"
 #include "ui/radar_theme.h"
 
-namespace fonts = lgfx::v1::fonts;
 
 namespace ui::runway {
 namespace {

--- a/src/ui/status_screens.cpp
+++ b/src/ui/status_screens.cpp
@@ -11,7 +11,6 @@
 #include "hardware/display.h"
 #include "hardware/display_font.h"
 
-namespace fonts = lgfx::v1::fonts;
 
 namespace {
 


### PR DESCRIPTION
First of all, thank you so much, this is a really cool project! I ran into some issues that I fixed in this pr:

LovyanGFX declares a global compat namespace 'fonts' in lgfx_fonts.hpp, so the alias declarations collide and break the build with current library versions. The global namespace already provides the same names.