### PR TITLE
Fix memory consumption/fragmentation issues and

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -17,6 +17,8 @@ constexpr char kPortalHostUrl[] = "plane-radar.local";
 constexpr unsigned long kWifiConnectAttemptMs = 15000;
 constexpr uint8_t kWifiConnectAttempts = 3;
 constexpr unsigned long kWifiPortalTimeoutSec = 0;  // 0 = no timeout while configuring
+constexpr unsigned long kPortalIdleTimeoutMs = 300000;  // Unload config portal after 5 minutes of inactivity
+                                                        // to minimise memory footprint
 constexpr unsigned long kWifiConnectingFrameMs = 50;
 /** Wait after disconnect before reconnecting (avoids portal on brief drops). */
 constexpr unsigned long kWifiDownGraceMs = 4000;

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -21,12 +21,62 @@ constexpr unsigned long kRequestTimeoutMs = 10000;
 Aircraft s_aircraft[kMaxAircraft];
 size_t s_aircraft_count = 0;
 PollFn s_poll_fn = nullptr;
+WiFiClientSecure s_client;
+HTTPClient s_http;
+bool s_tls_configured = false;
 
 void pollNetwork() {
   if (s_poll_fn != nullptr) {
     s_poll_fn();
   }
 }
+
+class PollingStream : public Stream {
+ public:
+  explicit PollingStream(Stream& inner) : inner_(inner) {}
+
+  int available() override {
+    return (buf_pos_ < buf_len_) ? (buf_len_ - buf_pos_) : refill();
+  }
+
+  int read() override {
+    if (buf_pos_ >= buf_len_ && refill() <= 0) return -1;
+    return buf_[buf_pos_++];
+  }
+
+  int peek() override {
+    if (buf_pos_ >= buf_len_ && refill() <= 0) return -1;
+    return buf_[buf_pos_];
+  }
+
+  size_t readBytes(uint8_t* out, size_t len) override {
+    size_t total = 0;
+    while (total < len) {
+      if (buf_pos_ >= buf_len_ && refill() <= 0) break;
+      size_t avail = buf_len_ - buf_pos_;
+      size_t take = avail < (len - total) ? avail : (len - total);
+      memcpy(out + total, buf_ + buf_pos_, take);
+      buf_pos_ += take;
+      total += take;
+    }
+    return total;
+  }
+
+  size_t write(uint8_t) override { return 0; }
+
+ private:
+  int refill() {
+    pollNetwork();  // call per chunk
+    buf_len_ = inner_.readBytes(buf_, sizeof(buf_));
+    buf_pos_ = 0;
+    return buf_len_;
+  }
+
+  Stream& inner_;
+  uint8_t buf_[256];
+  size_t buf_pos_ = 0;
+  size_t buf_len_ = 0;
+};
 
 int performGetWithPoll(HTTPClient& http) {
   http.setConnectTimeout(kConnectAttemptMs);
@@ -205,6 +255,37 @@ size_t aircraftCount() { return s_aircraft_count; }
 
 const Aircraft* aircraftList() { return s_aircraft; }
 
+void ensureClientConfigured() {
+  if (s_tls_configured) return;
+
+  s_client.setInsecure();
+  s_tls_configured = true;
+}
+
+JsonDocument& filterDoc() {
+  static JsonDocument filter;
+  static bool initialized = false;
+  if (!initialized) {
+    JsonObject filter_ac = filter["ac"].add<JsonObject>();
+    filter_ac["hex"] = true;
+    filter_ac["flight"] = true;
+    filter_ac["t"] = true;
+    filter_ac["lat"] = true;
+    filter_ac["lon"] = true;
+    filter_ac["alt_baro"] = true;
+    filter_ac["alt_geom"] = true;
+    filter_ac["gs"] = true;
+    filter_ac["tas"] = true;
+    filter_ac["ias"] = true;
+    filter_ac["track"] = true;
+    filter_ac["true_heading"] = true;
+    filter_ac["mag_heading"] = true;
+    filter_ac["dir"] = true;
+    initialized = true;
+  }
+  return filter;
+}
+
 bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
   const float dist_nm = kmToNauticalMiles(fetch_radius_km);
 
@@ -215,33 +296,28 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
   url += "/dist/";
   url += String(dist_nm, 1);
 
-  WiFiClientSecure client;
-  client.setInsecure();
+  ensureClientConfigured();
 
-  HTTPClient http;
-  if (!http.begin(client, url)) {
+  if (!s_http.begin(s_client, url)) {
     Serial.println("adsb: http.begin failed");
     return false;
   }
 
-  http.setTimeout(kRequestTimeoutMs);
-  const int code = performGetWithPoll(http);
+  s_http.setTimeout(kRequestTimeoutMs);
+
+  const int code = performGetWithPoll(s_http);
   if (code != HTTP_CODE_OK) {
     Serial.printf("adsb: HTTP %d\n", code);
-    http.end();
+    s_http.end();
     return false;
   }
 
-  String payload;
-  if (!readResponseBodyWithPoll(http, payload)) {
-    Serial.println("adsb: empty response");
-    http.end();
-    return false;
-  }
-  http.end();
-
+  PollingStream polling_stream(*s_http.getStreamPtr());
   JsonDocument doc;
-  const DeserializationError err = deserializeJson(doc, payload);
+  const DeserializationError err = deserializeJson(
+    doc, polling_stream, DeserializationOption::Filter(filterDoc()));
+  s_http.end();
+
   if (err) {
     Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
     return false;

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -24,7 +24,11 @@ volatile bool s_boot_is_down = false;
 volatile unsigned long s_boot_down_ms = 0;
 bool s_long_press_handled = false;
 bool s_boot_interrupt_attached = false;
+unsigned long s_portal_last_activity_ms = 0;
 
+void touchPortalActivity() {
+  s_portal_last_activity_ms = millis();
+}
 void IRAM_ATTR onBootButtonIsr() {
   const bool down = digitalRead(config::kBootPin) == LOW;
   const unsigned long now = millis();
@@ -100,6 +104,9 @@ void refreshPortalParamDefaults() {
 }
 
 void onPortalParamsSaved() {
+  // Keep portal alive
+  touchPortalActivity();
+
   if (!services::location::saveFromStrings(s_param_lat.getValue(),
                                            s_param_lon.getValue())) {
     Serial.println("Invalid lat/lon in portal — keeping previous location");
@@ -243,6 +250,7 @@ void startLanWebPortal() {
   }
 #endif
   s_wm.startWebPortal();
+  touchPortalActivity();
   Serial.printf("LAN config: http://%s.local or http://%s\n",
                 config::kPortalHostname, WiFi.localIP().toString().c_str());
 }
@@ -418,12 +426,17 @@ bool wifiReconnect() {
 void wifiLoop() {
   ensureWifiManager();
   if (wifiLinkUp()) {
-    if (!s_wm.getWebPortalActive() && !s_wm.getConfigPortalActive()) {
-      startLanWebPortal();
-    }
+    startLanWebPortal();
+
     if (s_wm.getWebPortalActive() || s_wm.getConfigPortalActive()) {
       bootButtonPollLongPress();
       s_wm.process();
+
+      if (s_wm.getWebPortalActive() &&
+          millis() - s_portal_last_activity_ms >= config::kPortalIdleTimeoutMs) {
+        Serial.println("LAN portal idle timeout - stopping");
+        stopLanWebPortal();
+      }
     }
   } else {
     stopLanWebPortal();

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -15,8 +15,6 @@
 #include "ui/radar_theme.h"
 #include "ui/runway_overlay.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui {
 namespace radar {
 
@@ -41,9 +39,9 @@ bool s_scale_use_vlw = false;
 float s_cardinal_vlw_size = 0.56f;
 float s_scale_vlw_size = 0.50f;
 float s_tag_vlw_size = 0.56f;
-const lgfx::GFXfont* s_cardinal_gfx = &fonts::FreeSansBold12pt7b;
+const lgfx::GFXfont* s_cardinal_gfx = &fonts::FreeSansBold9pt7b;
 const lgfx::GFXfont* s_scale_gfx = &fonts::FreeSansBold9pt7b;
-const lgfx::GFXfont* s_tag_gfx = &fonts::FreeSansBold12pt7b;
+const lgfx::GFXfont* s_tag_gfx = &fonts::FreeSansBold9pt7b;
 
 bool s_tag_label_metrics_ready = false;
 bool s_tag_use_vlw = false;

--- a/src/ui/radar_range.cpp
+++ b/src/ui/radar_range.cpp
@@ -15,7 +15,7 @@ constexpr char kPrefsNamespace[] = "planeradar";
 constexpr char kPrefsRangeKey[] = "rangeIdx";
 constexpr char kPrefsMilesKey[] = "useMiles";
 constexpr char kPrefsRunwaysKey[] = "showRwys";
-constexpr uint8_t kDefaultRangeIndex = 1;  // 10 km ring
+constexpr uint8_t kDefaultRangeIndex = 2;
 constexpr float kKmPerMile = 1.609344f;
 
 Preferences s_prefs;

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -11,8 +11,6 @@
 #include "ui/radar_range.h"
 #include "ui/radar_theme.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui::runway {
 namespace {
 

--- a/src/ui/status_screens.cpp
+++ b/src/ui/status_screens.cpp
@@ -11,8 +11,6 @@
 #include "hardware/display.h"
 #include "hardware/display_font.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace {
 
 constexpr int kLineGap = 6;
@@ -38,12 +36,12 @@ float s_spinner_angle_deg = -90.0f;
 SpinnerDot s_spinner_dots[kSpinnerDotCount];
 bool s_connecting_text_drawn = false;
 
-constexpr auto& kGfxTitle = fonts::FreeSans18pt7b;
-constexpr auto& kGfxBody = fonts::FreeSans12pt7b;
+constexpr auto& kGfxTitle = fonts::FreeSans12pt7b;
+constexpr auto& kGfxBody = fonts::FreeSans9pt7b;
 constexpr auto& kGfxDetail = fonts::Font2;
-constexpr auto& kPortalGfxTitle = fonts::FreeSansBold18pt7b;
-constexpr auto& kPortalGfxBody = fonts::FreeSansBold12pt7b;
-constexpr auto& kPortalGfxEmphasis = fonts::FreeSansBold18pt7b;
+constexpr auto& kPortalGfxTitle = fonts::FreeSansBold12pt7b;
+constexpr auto& kPortalGfxBody = fonts::FreeSansBold9pt7b;
+constexpr auto& kPortalGfxEmphasis = fonts::FreeSansBold12pt7b;
 constexpr auto& kConnectingGfxDetail = fonts::FreeSans9pt7b;
 
 struct TextLine {


### PR DESCRIPTION
I had a lot of trouble with JSON payload parsing randomly losing bytes, and after the esp32 has been running for some time, was also seeing errors relating to memory allocation for the SSL socket.

After some digging I have made a few changes. Most controversially, the config portal will now despawn after 5 minutes without a setting being changed. I figure I don't really need it much but can always reboot to launch it.

The adsb_client.cpp changes are all for memory optimisation. The client objects are now reused, and `PollingStream` replaces `payload.concat()` so data is now streamed in directly, avoiding an intermediate string buffer, which is what was causing the random missing API response bytes. `PollingStream` uses a chunked buffer so that `pollNetwork()` can be called at an appropriate rate.

I also asked Claude for its opinions on the ADSB client and it suggested adding a deserialisation filter that eliminates all the extraneous keys from the JSON payloads, that seems to work well so I've included it also.

Finally, I tweaked the font sizes for when font smoothing is disabled as some of them were huge.

If there is interest in merging any of this work but you want to de-scope any of it let me know and I will amend the PR accordingly.