### PR TITLE
Add new option to remove airport labels

### DIFF
--- a/include/ui/radar_range.h
+++ b/include/ui/radar_range.h
@@ -45,9 +45,11 @@ float fetchRadiusKm();
 
 bool useMiles();
 bool showRunways();
+bool showRunwayLabels();
 /** WiFi portal checkbox: "T" = miles, otherwise km. */
 void saveMilesFromPortal(const char* checkbox_value);
 void saveRunwaysFromPortal(const char* checkbox_value);
+void saveRunwayLabelsFromPortal(const char* checkbox_value);
 void formatRing3Label(char* buf, size_t len, float ring3_km, bool use_miles);
 void formatCurrentRing3Label(char* buf, size_t len);
 /** Reset distance units to km (e.g. with WiFi credential wipe). */

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -84,6 +84,10 @@ char s_runways_checkbox_attrs[32] = "type=\"checkbox\"";
 WiFiManagerParameter s_param_runways("show_runways", "Show airport runways", "T", 2,
                                      s_runways_checkbox_attrs, WFM_LABEL_AFTER);
 
+char s_runwaylabels_checkbox_attrs[32] = "type=\"checkbox\"";
+WiFiManagerParameter s_param_runwaylabels("show_runwaylabels", "Show airport runway labels", "T", 2,
+                                     s_runwaylabels_checkbox_attrs, WFM_LABEL_AFTER);
+
 void refreshPortalParamDefaults() {
   char lat_buf[kCoordParamLen + 1];
   char lon_buf[kCoordParamLen + 1];
@@ -97,6 +101,9 @@ void refreshPortalParamDefaults() {
   snprintf(s_runways_checkbox_attrs, sizeof(s_runways_checkbox_attrs),
            "type=\"checkbox\"%s", ui::radar::showRunways() ? " checked" : "");
   s_param_runways.setValue("T", 2);
+  snprintf(s_runwaylabels_checkbox_attrs, sizeof(s_runwaylabels_checkbox_attrs),
+           "type=\"checkbox\"%s", ui::radar::showRunwayLabels() ? " checked" : "");
+  s_param_runwaylabels.setValue("T", 2);
 }
 
 void onPortalParamsSaved() {
@@ -106,6 +113,7 @@ void onPortalParamsSaved() {
   }
   ui::radar::saveMilesFromPortal(s_param_miles.getValue());
   ui::radar::saveRunwaysFromPortal(s_param_runways.getValue());
+  ui::radar::saveRunwayLabelsFromPortal(s_param_runwaylabels.getValue());
 }
 
 void attachPortalParams(WiFiManager& wm) {
@@ -114,6 +122,7 @@ void attachPortalParams(WiFiManager& wm) {
   wm.addParameter(&s_param_lon);
   wm.addParameter(&s_param_miles);
   wm.addParameter(&s_param_runways);
+  wm.addParameter(&s_param_runwaylabels);
   wm.setSaveParamsCallback(onPortalParamsSaved);
 }
 

--- a/src/ui/radar_range.cpp
+++ b/src/ui/radar_range.cpp
@@ -15,6 +15,7 @@ constexpr char kPrefsNamespace[] = "planeradar";
 constexpr char kPrefsRangeKey[] = "rangeIdx";
 constexpr char kPrefsMilesKey[] = "useMiles";
 constexpr char kPrefsRunwaysKey[] = "showRwys";
+constexpr char kPrefsRunwayLabelsKey[] = "showRwLb";
 constexpr uint8_t kDefaultRangeIndex = 1;  // 10 km ring
 constexpr float kKmPerMile = 1.609344f;
 
@@ -22,6 +23,7 @@ Preferences s_prefs;
 uint8_t s_range_index = kDefaultRangeIndex;
 bool s_use_miles = false;
 bool s_show_runways = true;
+bool s_show_runwaylabels = true;
 
 void saveRangeIndex() {
   if (!s_prefs.begin(kPrefsNamespace, false)) {
@@ -44,6 +46,14 @@ void saveShowRunways() {
     return;
   }
   s_prefs.putBool(kPrefsRunwaysKey, s_show_runways);
+  s_prefs.end();
+}
+
+void saveShowRunwayLabels() {
+  if (!s_prefs.begin(kPrefsNamespace, false)) {
+    return;
+  }
+  s_prefs.putBool(kPrefsRunwayLabelsKey, s_show_runwaylabels);
   s_prefs.end();
 }
 
@@ -70,6 +80,7 @@ void rangeInit() {
       (saved < kRangePresetCount) ? saved : kDefaultRangeIndex;
   s_use_miles = s_prefs.getBool(kPrefsMilesKey, false);
   s_show_runways = s_prefs.getBool(kPrefsRunwaysKey, true);
+  s_show_runwaylabels = s_prefs.getBool(kPrefsRunwayLabelsKey, true);
   s_prefs.end();
 }
 
@@ -93,6 +104,8 @@ bool useMiles() { return s_use_miles; }
 
 bool showRunways() { return s_show_runways; }
 
+bool showRunwayLabels() { return s_show_runwaylabels; }
+
 void saveMilesFromPortal(const char* checkbox_value) {
   s_use_miles = portalCheckboxChecked(checkbox_value);
   saveUseMiles();
@@ -103,6 +116,12 @@ void saveRunwaysFromPortal(const char* checkbox_value) {
   s_show_runways = portalCheckboxChecked(checkbox_value);
   saveShowRunways();
   Serial.printf("Runway overlay: %s\n", s_show_runways ? "on" : "off");
+}
+
+void saveRunwayLabelsFromPortal(const char* checkbox_value) {
+  s_show_runwaylabels = portalCheckboxChecked(checkbox_value);
+  saveShowRunwayLabels();
+  Serial.printf("Runway label overlay: %s\n", s_show_runwaylabels ? "on" : "off");
 }
 
 void formatRing3Label(char* buf, size_t len, float ring3_km, bool use_miles) {
@@ -122,9 +141,11 @@ void formatCurrentRing3Label(char* buf, size_t len) {
 void unitsReset() {
   s_use_miles = false;
   s_show_runways = true;
+  s_show_runwaylabels = true;
   if (s_prefs.begin(kPrefsNamespace, false)) {
     s_prefs.remove(kPrefsMilesKey);
     s_prefs.remove(kPrefsRunwaysKey);
+    s_prefs.remove(kPrefsRunwayLabelsKey);
     s_prefs.end();
   }
 }

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -288,6 +288,10 @@ void drawLargeAirportRunways(lgfx::LGFXBase& gfx) {
     return;
   }
 
+  if (!radar::showRunwayLabels()) {
+    return;
+  }
+
   initRunwayLabelStyle(gfx);
   applyRunwayLabelStyle(gfx);
   for (size_t i = 0; i < label_count; ++i) {


### PR DESCRIPTION
By default airport labels are shown.  This option in the wifi config allows them to be hidden.