### PR TITLE
Fix build against LovyanGFX >= 1.2.x: drop redundant fonts alias

### DIFF
--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -15,8 +15,6 @@
 #include "ui/radar_theme.h"
 #include "ui/runway_overlay.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui {
 namespace radar {
 

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -11,8 +11,6 @@
 #include "ui/radar_range.h"
 #include "ui/radar_theme.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui::runway {
 namespace {
 

--- a/src/ui/status_screens.cpp
+++ b/src/ui/status_screens.cpp
@@ -11,8 +11,6 @@
 #include "hardware/display.h"
 #include "hardware/display_font.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace {
 
 constexpr int kLineGap = 6;


### PR DESCRIPTION
LovyanGFX declares a global `namespace fonts` and a `using namespace fonts;` in lgfx/v1/lgfx_fonts.hpp. The `namespace fonts = lgfx::v1::fonts;` alias in three translation units collides with it:

    error: 'namespace fonts = lgfx::v1::lgfx::v1::fonts;'
           conflicts with a previous declaration

The alias is redundant now that the library exposes `fonts` globally, so remove it rather than pinning the dependency backwards.

CI does not catch this: the cache key falls back to restore-keys `${{ runner.os }}-pio-`, restoring a libdeps tree whose older LovyanGFX still satisfies `^1.2.7`. A fresh checkout resolves 1.2.25 and fails to compile.

Verified: pio run -e supermini succeeds (RAM 15.5%, Flash 39.4%).