### PR TITLE
fix: ADS-B response truncation and radar longitude projection

### DIFF
--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -46,43 +46,66 @@ int performGetWithPoll(HTTPClient& http) {
   return HTTPC_ERROR_READ_TIMEOUT;
 }
 
-bool readResponseBodyWithPoll(HTTPClient& http, String& payload) {
-  WiFiClient* stream = http.getStreamPtr();
-  if (stream == nullptr) {
-    return false;
-  }
+/**
+ * Stream wrapper that keeps the rest of the firmware alive during blocking
+ * HTTP reads and bounds the whole body transfer with a single deadline.
+ *
+ * The response is parsed straight off this stream rather than buffered: a
+ * busy sector easily exceeds 20 kB, and the heap is too fragmented to hold
+ * that in one contiguous allocation.
+ */
+class PollingStream : public Stream {
+ public:
+  PollingStream(WiFiClient* source, unsigned long deadline)
+      : source_(source), deadline_(deadline) {}
 
-  const int content_length = http.getSize();
-  if (content_length > 0) {
-    payload.reserve(static_cast<unsigned>(content_length + 1));
-  }
+  int available() override { return source_->available(); }
+  int peek() override { return waitForData() ? source_->peek() : -1; }
+  void flush() override {}
+  size_t write(uint8_t) override { return 0; }
 
-  uint8_t buffer[512];
-  const unsigned long deadline = millis() + kRequestTimeoutMs;
-  while (millis() < deadline) {
-    pollNetwork();
-    const int available = stream->available();
-    if (available > 0) {
-      const int to_read =
-          available > static_cast<int>(sizeof(buffer)) ? static_cast<int>(sizeof(buffer))
-                                                       : available;
-      const int read_bytes = stream->readBytes(buffer, to_read);
-      if (read_bytes > 0) {
-        payload.concat(reinterpret_cast<const char*>(buffer),
-                       static_cast<unsigned>(read_bytes));
+  int read() override { return waitForData() ? source_->read() : -1; }
+
+  size_t readBytes(char* buffer, size_t length) override {
+    size_t got = 0;
+    while (got < length && waitForData()) {
+      const int n = source_->read(reinterpret_cast<uint8_t*>(buffer + got),
+                                  length - got);
+      if (n > 0) {
+        got += static_cast<size_t>(n);
       }
     }
-    if (content_length > 0 &&
-        static_cast<int>(payload.length()) >= content_length) {
-      break;
-    }
-    if (!http.connected() && stream->available() <= 0) {
-      break;
-    }
-    delay(1);
+    return got;
   }
 
-  return payload.length() > 0;
+ private:
+  /** Blocks until a byte is ready, the peer hangs up, or the deadline hits. */
+  bool waitForData() {
+    while (source_->available() <= 0) {
+      if (millis() >= deadline_) {
+        return false;
+      }
+      if (!source_->connected()) {
+        return source_->available() > 0;
+      }
+      pollNetwork();
+      delay(1);
+    }
+    return true;
+  }
+
+  WiFiClient* source_;
+  unsigned long deadline_;
+};
+
+/** Keeps only the fields the radar actually renders. */
+void buildPlaneFilter(JsonDocument& filter) {
+  static const char* const kKeys[] = {
+      "lat", "lon", "true_heading", "mag_heading", "track",    "dir", "gs",
+      "tas", "ias", "alt_baro",     "alt_geom",    "flight",   "hex", "t"};
+  for (const char* key : kKeys) {
+    filter[key] = true;
+  }
 }
 
 float kmToNauticalMiles(float km) { return km / kKmPerNm; }
@@ -232,46 +255,65 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
     return false;
   }
 
-  String payload;
-  if (!readResponseBodyWithPoll(http, payload)) {
-    Serial.println("adsb: empty response");
+  WiFiClient* source = http.getStreamPtr();
+  if (source == nullptr) {
+    Serial.println("adsb: no response stream");
     http.end();
     return false;
   }
-  http.end();
 
-  JsonDocument doc;
-  const DeserializationError err = deserializeJson(doc, payload);
-  if (err) {
-    Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
-    return false;
-  }
+  PollingStream stream(source, millis() + kRequestTimeoutMs);
+  stream.setTimeout(kRequestTimeoutMs);
 
-  JsonArray ac = doc["ac"].as<JsonArray>();
-  if (ac.isNull()) {
+  // Walk to the start of the "ac" array; two steps so `"ac" : [` also matches.
+  if (!stream.find("\"ac\"") || !stream.find("[")) {
+    Serial.println("adsb: no aircraft array in response");
+    http.end();
     s_aircraft_count = 0;
     return true;
   }
 
-  size_t n = 0;
-  for (JsonObject plane : ac) {
-    if (n >= kMaxAircraft) {
-      break;
-    }
-    if (!plane["lat"].is<float>() || !plane["lon"].is<float>()) {
-      continue;
-    }
-    if (isOnGround(plane) && !config::kAdsbShowGroundAircraft) {
-      continue;
-    }
+  JsonDocument filter;
+  buildPlaneFilter(filter);
 
-    s_aircraft[n].lat = plane["lat"].as<float>();
-    s_aircraft[n].lon = plane["lon"].as<float>();
-    s_aircraft[n].nose_deg = pickNoseHeading(plane);
-    s_aircraft[n].track_deg = pickTrackHeading(plane);
-    s_aircraft[n].gs_knots = pickGroundSpeed(plane);
-    fillTagFields(&s_aircraft[n], plane);
-    ++n;
+  size_t n = 0;
+  bool ok = true;
+  if (stream.peek() != ']') {  // guard against an empty "ac":[] array
+    do {
+      // One aircraft at a time: peak memory stays a few hundred bytes
+      // instead of the ~20 kB the full document would need.
+      JsonDocument plane_doc;
+      const DeserializationError err = deserializeJson(
+          plane_doc, stream, DeserializationOption::Filter(filter));
+      if (err) {
+        Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
+        ok = false;
+        break;
+      }
+
+      JsonObject plane = plane_doc.as<JsonObject>();
+      if (n < kMaxAircraft && plane["lat"].is<float>() &&
+          plane["lon"].is<float>() &&
+          (config::kAdsbShowGroundAircraft || !isOnGround(plane))) {
+        s_aircraft[n].lat = plane["lat"].as<float>();
+        s_aircraft[n].lon = plane["lon"].as<float>();
+        s_aircraft[n].nose_deg = pickNoseHeading(plane);
+        s_aircraft[n].track_deg = pickTrackHeading(plane);
+        s_aircraft[n].gs_knots = pickGroundSpeed(plane);
+        fillTagFields(&s_aircraft[n], plane);
+        ++n;
+      }
+
+      if (n >= kMaxAircraft) {
+        break;  // enough to draw; drop the rest of the body
+      }
+    } while (stream.findUntil(",", "]"));
+  }
+
+  http.end();
+
+  if (!ok && n == 0) {
+    return false;
   }
 
   s_aircraft_count = n;

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -15,8 +15,6 @@
 #include "ui/radar_theme.h"
 #include "ui/runway_overlay.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui {
 namespace radar {
 

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -201,8 +201,13 @@ constexpr float kKmPerDeg = 111.0f;
 
 void offsetKmFromCenter(float lat, float lon, float* dx_km, float* dy_km,
                         float* dist_km) {
-  *dx_km =
-      static_cast<float>(lon - services::location::lon()) * kKmPerDeg;
+  // A degree of longitude shrinks as cos(latitude); without this an east-west
+  // offset reads ~38% too far at 43°N, pushing aircraft outside the ring.
+  const float center_lat = static_cast<float>(services::location::lat());
+  const float lon_scale = cosf(center_lat * static_cast<float>(M_PI) / 180.0f);
+
+  *dx_km = static_cast<float>(lon - services::location::lon()) * kKmPerDeg *
+           lon_scale;
   *dy_km =
       static_cast<float>(lat - services::location::lat()) * kKmPerDeg;
   *dist_km = sqrtf((*dx_km) * (*dx_km) + (*dy_km) * (*dy_km));

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -11,8 +11,6 @@
 #include "ui/radar_range.h"
 #include "ui/radar_theme.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui::runway {
 namespace {
 

--- a/src/ui/status_screens.cpp
+++ b/src/ui/status_screens.cpp
@@ -11,8 +11,6 @@
 #include "hardware/display.h"
 #include "hardware/display_font.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace {
 
 constexpr int kLineGap = 6;


### PR DESCRIPTION
Two independent bugs found while bringing this up on an ESP32-C3 Super Mini with the 1.28" round GC9A01, plus the build fix needed to flash anything at all. Each is a separate commit.

---

## 1. ~90% of ADS-B fetches fail with a JSON parse error

```
adsb: JSON parse error: InvalidInput
adsb: JSON parse error: InvalidInput
adsb: JSON parse error: IncompleteInput
```

### Root cause

`fetchUpdate()` buffered the whole response body into a `String` before parsing. Instrumenting the read loop on hardware:

```
DBG read: why=deadline ms=10001 read=21040 len=11112 concat_fail=1 heap=30788 maxblk=9204
DBG size=21040 cl=[21040] te=[] ce=[]
DBG head=[{"ac":[ {"hex":"c012ed","type":"adsb_icao","flight":"ACA1511 ",...
```

* `read=21040` — the socket delivers the **full** body and it starts as valid JSON. Not a transport, TLS, or API problem, and not chunked encoding (`te=[]`).
* `heap=30788` / **`maxblk=9204`** — ~30 kB free heap, but the largest *contiguous* block is ~9 kB. `payload.reserve(21041)` needs one contiguous 21 kB allocation and fails.
* **`concat_fail=1`** — the following `String::concat()` calls fail, so the buffer tops out at 10–14 kB and `deserializeJson()` gets a truncated body.
* `why=deadline ms=10001` — a second bug falls out of the first: `payload.length()` can never reach `content_length`, so the loop never takes its completion branch and burns the **full 10 s timeout on every fetch**.

This is heap fragmentation, not payload size as such — there is enough free heap for 21 kB, just never in one piece. Responses small enough to fit still succeed, which is the surviving ~10%.

### Fix

Parse directly off the response stream, one aircraft at a time, with a `DeserializationOption::Filter` restricting the document to the fields the radar renders. Peak memory drops from ~21 kB contiguous to a few hundred bytes. A small `PollingStream` preserves the existing network-poll-hook behaviour during blocking reads and bounds the transfer with one deadline. Parsing stops early once `kMaxAircraft` is reached.

### Verification

Before — ~90% failure. After — 25 consecutive fetches, 0 parse errors, each completing at the real 3 s poll interval instead of stalling 10 s:

```
adsb: 13 aircraft
adsb: 13 aircraft
adsb: 12 aircraft
```

---

## 2. Aircraft vanish at the 5 km and 10 km presets

Everything looked frozen at short ranges, while the 25 km preset worked fine.

### Root cause

`offsetKmFromCenter()` converts longitude degrees to km with a flat `111 km/°` and no `cos(latitude)` correction, so every east-west offset is overstated — ~38% at 43°N.

On hardware at the 10 km preset, radar centred at `43.6485,-79.4795`:

```
DBG draw: n=4 inside=0 dots=4 outer=13.3km max=11.7km
POE662  dx=-14.5 dist=14.6km -> (4,104)     true dx=-10.5, true dist=10.7km (INSIDE)
RPA4438 dx=+16.2 dist=16.8km -> (250,153)   x=250 is off a 240px panel
PTR2264 dx=+16.3 dist=16.3km -> (251,125)
```

Aircraft genuinely inside the ring measure as beyond it and are demoted from a full symbol + callsign/type/altitude tag to a 2 px rim dot — `inside=0`, i.e. every aircraft. That reads as "the planes disappeared". Projected x can also land off-panel entirely. The 25 km preset masks it because its 33 km outer radius is wide enough that even inflated distances still fall inside.

### Fix

Scale the longitude delta by `cos(centre latitude)`.

### Verification

Same location and traffic, after the fix:

```
DBG draw: n=8 inside=7 dots=1 outer=20.0km max=17.6km
```

Aircraft that previously rendered as rim dots now project inside the ring, and off-panel x coordinates are gone.

---

## 3. Build fix (required to flash anything)

LovyanGFX resolves to 1.2.26 under `@^1.2.7` and now exposes `fonts` at global scope, so the three local aliases collide:

```
src/ui/status_screens.cpp:14:34: error: 'namespace fonts = lgfx::v1::lgfx::v1::fonts;' conflicts with a previous declaration
```

Removed the three `namespace fonts = lgfx::v1::fonts;` aliases; `fonts::` already resolves without them. Pinning the library version instead would also work if you'd prefer that — happy to switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
