### PR TITLE
Fix build error with LovyanGFX 1.2.26 font namespace conflict

### DIFF
--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -15,8 +15,6 @@
 #include "ui/radar_theme.h"
 #include "ui/runway_overlay.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui {
 namespace radar {
 

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -11,8 +11,6 @@
 #include "ui/radar_range.h"
 #include "ui/radar_theme.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace ui::runway {
 namespace {
 

--- a/src/ui/status_screens.cpp
+++ b/src/ui/status_screens.cpp
@@ -11,8 +11,6 @@
 #include "hardware/display.h"
 #include "hardware/display_font.h"
 
-namespace fonts = lgfx::v1::fonts;
-
 namespace {
 
 constexpr int kLineGap = 6;


### PR DESCRIPTION
LovyanGFX 1.2.26 (which `lovyan03/LovyanGFX @ ^1.2.7` now resolves to) declares a global `namespace fonts` in `lgfx_fonts.hpp`, which conflicts with the `namespace fonts = lgfx::v1::fonts;` alias declared in three UI source files and breaks the build. This removes those now-redundant aliases; the `fonts::` references still resolve via the header's own global namespace. Verified with a clean `pio run -e supermini` build (SUCCESS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)