### PR TITLE
Fix saved 32-byte WiFi SSID on ESP32

### DIFF
--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -4,6 +4,7 @@
 #include <WiFiManager.h>
 
 #include <cstdio>
+#include <cstring>
 
 #include <Preferences.h>
 #include <esp_system.h>
@@ -316,16 +317,35 @@ bool tryConnectWithUi(const String& ssid, const String& pass, bool show_ui) {
 }
 
 bool connectSavedNetwork(bool show_ui) {
-  if (!storedWifiCredentials()) {
+  wifi_mode_t mode = WIFI_MODE_NULL;
+  if (esp_wifi_get_mode(&mode) != ESP_OK || mode == WIFI_MODE_NULL) {
+    WiFi.mode(WIFI_STA);
+    delay(50);
+  }
+
+  wifi_config_t conf = {};
+  if (esp_wifi_get_config(WIFI_IF_STA, &conf) != ESP_OK) {
     return false;
   }
 
-  ensureWifiManager();
-  const String ssid = s_wm.getWiFiSSID();
-  if (ssid.length() == 0) {
+  if (conf.sta.ssid[0] == '\0') {
     return false;
   }
-  const String pass = s_wm.getWiFiPass();
+
+  // ESP-IDF stores the SSID in a fixed 32-byte field. A maximum-length
+  // SSID has no room for a trailing NUL, so copy it to a larger buffer
+  // and explicitly terminate it before constructing an Arduino String.
+  char ssid_buf[sizeof(conf.sta.ssid) + 1] = {};
+  memcpy(ssid_buf, conf.sta.ssid, sizeof(conf.sta.ssid));
+  ssid_buf[sizeof(conf.sta.ssid)] = '\0';
+
+  char pass_buf[sizeof(conf.sta.password) + 1] = {};
+  memcpy(pass_buf, conf.sta.password, sizeof(conf.sta.password));
+  pass_buf[sizeof(conf.sta.password)] = '\0';
+
+  const String ssid(ssid_buf);
+  const String pass(pass_buf);
+
   return tryConnectWithUi(ssid, pass, show_ui);
 }
 


### PR DESCRIPTION
## Summary

Fix reconnecting to a saved WiFi network when the SSID uses the full 32-byte ESP32 SSID field.

## Problem

The initial WiFi connection works correctly after configuration.

However, after a reboot, devices using a 32-byte SSID may fail to reconnect because the saved SSID can be read past the end of its fixed-size buffer.

ESP-IDF stores the station SSID in a fixed 32-byte field:

```cpp
ssid[32]
```

When all 32 bytes are used, there is no room for a trailing NUL character.

As a result, the SSID may be interpreted as a longer C string and continue into the following data, which can make the password appear appended to the SSID.

## Fix

The saved WiFi configuration is now read with:

```cpp
esp_wifi_get_config()
```

The SSID and password are copied into local buffers with one additional byte and are explicitly NUL-terminated before Arduino `String` objects are created.

This safely supports a full 32-byte SSID without reading beyond the end of the ESP-IDF fields.

## Scope

This change only affects reconnecting with saved WiFi credentials.

It does not change:

- WiFi setup portal behavior
- Radar functionality
- Range settings
- Location settings
- Display behavior

## How to reproduce

1. Configure the device with a WiFi SSID that is exactly 32 bytes long.
2. Confirm the initial connection succeeds.
3. Power-cycle the ESP32-C3.
4. The device may fail to reconnect because the saved SSID is read incorrectly.

## How to verify the fix

1. Build and flash this branch.
2. Configure the same 32-byte SSID.
3. Power-cycle the device.
4. Confirm that it reconnects using the correct saved SSID.