### PR TITLE
Feature/rotatable compass headings

### DIFF
--- a/include/ui/radar_range.h
+++ b/include/ui/radar_range.h
@@ -49,9 +49,17 @@ float fetchRadiusKm();
 
 bool useMiles();
 bool showRunways();
+/** True heading, in degrees, displayed at the top of the radar. */
+uint16_t headingAtTopDeg();
+/** Rotate an east/north map offset into the configured screen orientation. */
+void rotateMapOffset(float east, float north, float* screen_east,
+                     float* screen_north);
+/** Convert a true heading to its clockwise screen-relative heading. */
+float headingToScreen(float heading_deg);
 /** WiFi portal checkbox: "T" = miles, otherwise km. */
 void saveMilesFromPortal(const char* checkbox_value);
 void saveRunwaysFromPortal(const char* checkbox_value);
+bool saveHeadingFromPortal(const char* heading_deg_value);
 void formatRing3Label(char* buf, size_t len, float ring3_km, bool use_miles);
 void formatCurrentRing3Label(char* buf, size_t len);
 /** Reset distance units to km (e.g. with WiFi credential wipe). */

--- a/include/ui/radar_range.h
+++ b/include/ui/radar_range.h
@@ -9,6 +9,7 @@ namespace ui::radar {
  * Range presets (label on ring 3 = ¾ of outer radius).
  *
  * Recommended for ADS-B on a 1.28″ display:
+ *   1 km  — high density areas
  *   5 km  — pattern / very local (airfield vicinity)
  *  10 km  — default; neighborhood spotting
  *  15 km  — wider local area
@@ -25,6 +26,7 @@ struct RangePreset {
 constexpr float kRing3ToOuterKm = 4.0f / 3.0f;
 
 constexpr RangePreset kRangePresets[] = {
+    {1.0f, 1.0f * kRing3ToOuterKm},
     {5.0f, 5.0f * kRing3ToOuterKm},
     {10.0f, 10.0f * kRing3ToOuterKm},
     {15.0f, 15.0f * kRing3ToOuterKm},
@@ -40,6 +42,8 @@ void rangeInit();
 void rangeNext();
 const RangePreset& rangeCurrent();
 uint8_t rangeIndex();
+/** Save a portal range value matching one of the configured ring-3 presets. */
+bool saveRangeFromPortal(const char* range_km_value);
 /** ADSB fetch radius (km): scaled to screen edge so beyond-ring dots have data. */
 float fetchRadiusKm();
 

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -46,46 +46,25 @@ int performGetWithPoll(HTTPClient& http) {
   return HTTPC_ERROR_READ_TIMEOUT;
 }
 
-bool readResponseBodyWithPoll(HTTPClient& http, String& payload) {
-  WiFiClient* stream = http.getStreamPtr();
-  if (stream == nullptr) {
-    return false;
-  }
-
-  const int content_length = http.getSize();
-  if (content_length > 0) {
-    payload.reserve(static_cast<unsigned>(content_length + 1));
-  }
-
-  uint8_t buffer[512];
-  const unsigned long deadline = millis() + kRequestTimeoutMs;
-  while (millis() < deadline) {
-    pollNetwork();
-    const int available = stream->available();
-    if (available > 0) {
-      const int to_read =
-          available > static_cast<int>(sizeof(buffer)) ? static_cast<int>(sizeof(buffer))
-                                                       : available;
-      const int read_bytes = stream->readBytes(buffer, to_read);
-      if (read_bytes > 0) {
-        payload.concat(reinterpret_cast<const char*>(buffer),
-                       static_cast<unsigned>(read_bytes));
-      }
-    }
-    if (content_length > 0 &&
-        static_cast<int>(payload.length()) >= content_length) {
-      break;
-    }
-    if (!http.connected() && stream->available() <= 0) {
-      break;
-    }
-    delay(1);
-  }
-
-  return payload.length() > 0;
-}
-
 float kmToNauticalMiles(float km) { return km / kKmPerNm; }
+
+void buildAircraftJsonFilter(JsonDocument& filter) {
+  JsonObject plane = filter["ac"][0].to<JsonObject>();
+  plane["lat"] = true;
+  plane["lon"] = true;
+  plane["true_heading"] = true;
+  plane["mag_heading"] = true;
+  plane["track"] = true;
+  plane["dir"] = true;
+  plane["gs"] = true;
+  plane["tas"] = true;
+  plane["ias"] = true;
+  plane["alt_baro"] = true;
+  plane["alt_geom"] = true;
+  plane["flight"] = true;
+  plane["hex"] = true;
+  plane["t"] = true;
+}
 
 bool readJsonFloat(const JsonObject& obj, const char* key, float* out) {
   if (obj[key].is<float>() || obj[key].is<double>() || obj[key].is<int>()) {
@@ -232,16 +211,14 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
     return false;
   }
 
-  String payload;
-  if (!readResponseBodyWithPoll(http, payload)) {
-    Serial.println("adsb: empty response");
-    http.end();
-    return false;
-  }
-  http.end();
-
+  // Parse directly from the network stream so large search radii do not need
+  // one contiguous response buffer. The filter retains only displayed fields.
+  JsonDocument filter;
+  buildAircraftJsonFilter(filter);
   JsonDocument doc;
-  const DeserializationError err = deserializeJson(doc, payload);
+  const DeserializationError err = deserializeJson(
+      doc, http.getStream(), DeserializationOption::Filter(filter));
+  http.end();
   if (err) {
     Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
     return false;

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -69,26 +69,34 @@ bool wifiLinkUp();
 
 constexpr int kCoordParamLen = 20;
 constexpr int kRangeParamLen = 3;
+constexpr int kHeadingParamLen = 3;
 constexpr char kCoordInputAttrs[] =
     " type=\"number\" step=\"0.000001\"";
+constexpr char kHeadingInputAttrs[] =
+    " type=\"number\" min=\"0\" max=\"359\" step=\"1\" inputmode=\"numeric\"";
 
 constexpr char kRangeSelectScript[] = R"HTML(
 <script>
 document.addEventListener('DOMContentLoaded',function(){
-  var input=document.querySelector('input[name="radar_range"]');
-  if(!input)return;
-  var select=document.createElement('select');
-  select.name=input.name;
-  select.id=input.id;
-  select.style.cssText='width:100%;padding:8px;margin:8px 0 16px';
-  ['1','5','10','15','25'].forEach(function(value){
-    var option=document.createElement('option');
-    option.value=value;
-    option.textContent=value+' km';
-    option.selected=value===input.value;
-    select.appendChild(option);
-  });
-  input.replaceWith(select);
+  function makeSelect(name,options){
+    var input=document.querySelector('input[name="'+name+'"]');
+    if(!input)return;
+    var select=document.createElement('select');
+    select.name=input.name;
+    select.id=input.id;
+    select.style.cssText='width:100%;padding:8px;margin:8px 0 16px';
+    options.forEach(function(item){
+      var option=document.createElement('option');
+      option.value=item[0];
+      option.textContent=item[1];
+      option.selected=item[0]===input.value;
+      select.appendChild(option);
+    });
+    input.replaceWith(select);
+  }
+  makeSelect('radar_range',[
+    ['1','1 km'],['5','5 km'],['10','10 km'],['15','15 km'],['25','25 km']
+  ]);
 });
 </script>
 )HTML";
@@ -100,6 +108,8 @@ WiFiManagerParameter s_param_lon("radar_lon", "Longitude (deg)", "0",
 
 WiFiManagerParameter s_param_range("radar_range", "Radar range", "10",
                                   kRangeParamLen);
+WiFiManagerParameter s_param_heading("heading_top", "Compass heading at top",
+                                    "0", kHeadingParamLen, kHeadingInputAttrs);
 
 char s_miles_checkbox_attrs[32] = "type=\"checkbox\"";
 WiFiManagerParameter s_param_miles("use_miles", "Display distances in miles", "T", 2,
@@ -113,6 +123,7 @@ void refreshPortalParamDefaults() {
   char lat_buf[kCoordParamLen + 1];
   char lon_buf[kCoordParamLen + 1];
   char range_buf[kRangeParamLen + 1];
+  char heading_buf[kHeadingParamLen + 1];
   snprintf(lat_buf, sizeof(lat_buf), "%.6f", services::location::lat());
   snprintf(lon_buf, sizeof(lon_buf), "%.6f", services::location::lon());
   s_param_lat.setValue(lat_buf, kCoordParamLen);
@@ -120,6 +131,9 @@ void refreshPortalParamDefaults() {
   snprintf(range_buf, sizeof(range_buf), "%.0f",
            ui::radar::rangeCurrent().ring3_km);
   s_param_range.setValue(range_buf, kRangeParamLen);
+  snprintf(heading_buf, sizeof(heading_buf), "%u",
+           ui::radar::headingAtTopDeg());
+  s_param_heading.setValue(heading_buf, kHeadingParamLen);
   snprintf(s_miles_checkbox_attrs, sizeof(s_miles_checkbox_attrs),
            "type=\"checkbox\"%s",
            ui::radar::useMiles() ? " checked" : "");
@@ -134,6 +148,7 @@ void onPortalParamsSaved() {
       s_wm.server->hasArg("radar_lat") ||
       s_wm.server->hasArg("radar_lon") ||
       s_wm.server->hasArg("radar_range") ||
+      s_wm.server->hasArg("heading_top") ||
       s_wm.server->hasArg("use_miles") ||
       s_wm.server->hasArg("show_runways");
   if (!has_application_params) {
@@ -151,6 +166,9 @@ void onPortalParamsSaved() {
   if (!ui::radar::saveRangeFromPortal(s_param_range.getValue())) {
     Serial.println("Invalid radar range in portal — use 1, 5, 10, 15, or 25 km");
   }
+  if (!ui::radar::saveHeadingFromPortal(s_param_heading.getValue())) {
+    Serial.println("Invalid compass heading — use a degree value from 0 to 359");
+  }
   ui::radar::saveMilesFromPortal(s_param_miles.getValue());
   ui::radar::saveRunwaysFromPortal(s_param_runways.getValue());
   refreshPortalParamDefaults();
@@ -161,6 +179,7 @@ void attachPortalParams(WiFiManager& wm) {
   wm.addParameter(&s_param_lat);
   wm.addParameter(&s_param_lon);
   wm.addParameter(&s_param_range);
+  wm.addParameter(&s_param_heading);
   wm.addParameter(&s_param_miles);
   wm.addParameter(&s_param_runways);
   wm.setSaveParamsCallback(onPortalParamsSaved);

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -68,13 +68,38 @@ void stopLanWebPortal();
 bool wifiLinkUp();
 
 constexpr int kCoordParamLen = 20;
+constexpr int kRangeParamLen = 3;
 constexpr char kCoordInputAttrs[] =
     " type=\"number\" step=\"0.000001\"";
+
+constexpr char kRangeSelectScript[] = R"HTML(
+<script>
+document.addEventListener('DOMContentLoaded',function(){
+  var input=document.querySelector('input[name="radar_range"]');
+  if(!input)return;
+  var select=document.createElement('select');
+  select.name=input.name;
+  select.id=input.id;
+  select.style.cssText='width:100%;padding:8px;margin:8px 0 16px';
+  ['1','5','10','15','25'].forEach(function(value){
+    var option=document.createElement('option');
+    option.value=value;
+    option.textContent=value+' km';
+    option.selected=value===input.value;
+    select.appendChild(option);
+  });
+  input.replaceWith(select);
+});
+</script>
+)HTML";
 
 WiFiManagerParameter s_param_lat("radar_lat", "Latitude (deg)", "0",
                                 kCoordParamLen, kCoordInputAttrs);
 WiFiManagerParameter s_param_lon("radar_lon", "Longitude (deg)", "0",
                                 kCoordParamLen, kCoordInputAttrs);
+
+WiFiManagerParameter s_param_range("radar_range", "Radar range", "10",
+                                  kRangeParamLen);
 
 char s_miles_checkbox_attrs[32] = "type=\"checkbox\"";
 WiFiManagerParameter s_param_miles("use_miles", "Display distances in miles", "T", 2,
@@ -87,11 +112,16 @@ WiFiManagerParameter s_param_runways("show_runways", "Show airport runways", "T"
 void refreshPortalParamDefaults() {
   char lat_buf[kCoordParamLen + 1];
   char lon_buf[kCoordParamLen + 1];
+  char range_buf[kRangeParamLen + 1];
   snprintf(lat_buf, sizeof(lat_buf), "%.6f", services::location::lat());
   snprintf(lon_buf, sizeof(lon_buf), "%.6f", services::location::lon());
   s_param_lat.setValue(lat_buf, kCoordParamLen);
   s_param_lon.setValue(lon_buf, kCoordParamLen);
-  snprintf(s_miles_checkbox_attrs, sizeof(s_miles_checkbox_attrs), "type=\"checkbox\"%s",
+  snprintf(range_buf, sizeof(range_buf), "%.0f",
+           ui::radar::rangeCurrent().ring3_km);
+  s_param_range.setValue(range_buf, kRangeParamLen);
+  snprintf(s_miles_checkbox_attrs, sizeof(s_miles_checkbox_attrs),
+           "type=\"checkbox\"%s",
            ui::radar::useMiles() ? " checked" : "");
   s_param_miles.setValue("T", 2);
   snprintf(s_runways_checkbox_attrs, sizeof(s_runways_checkbox_attrs),
@@ -100,18 +130,37 @@ void refreshPortalParamDefaults() {
 }
 
 void onPortalParamsSaved() {
+  const bool has_application_params =
+      s_wm.server->hasArg("radar_lat") ||
+      s_wm.server->hasArg("radar_lon") ||
+      s_wm.server->hasArg("radar_range") ||
+      s_wm.server->hasArg("use_miles") ||
+      s_wm.server->hasArg("show_runways");
+  if (!has_application_params) {
+    // WiFiManager can invoke this callback again for a later portal request
+    // that contains no application parameters. Its internal buffers have
+    // already been cleared at this point, so restore them without saving.
+    refreshPortalParamDefaults();
+    return;
+  }
+
   if (!services::location::saveFromStrings(s_param_lat.getValue(),
                                            s_param_lon.getValue())) {
     Serial.println("Invalid lat/lon in portal — keeping previous location");
   }
+  if (!ui::radar::saveRangeFromPortal(s_param_range.getValue())) {
+    Serial.println("Invalid radar range in portal — use 1, 5, 10, 15, or 25 km");
+  }
   ui::radar::saveMilesFromPortal(s_param_miles.getValue());
   ui::radar::saveRunwaysFromPortal(s_param_runways.getValue());
+  refreshPortalParamDefaults();
 }
 
 void attachPortalParams(WiFiManager& wm) {
   refreshPortalParamDefaults();
   wm.addParameter(&s_param_lat);
   wm.addParameter(&s_param_lon);
+  wm.addParameter(&s_param_range);
   wm.addParameter(&s_param_miles);
   wm.addParameter(&s_param_runways);
   wm.setSaveParamsCallback(onPortalParamsSaved);
@@ -223,6 +272,7 @@ void ensureWifiManager() {
   s_wm.setAPStaticIPConfig(IPAddress(192, 168, 4, 1), IPAddress(192, 168, 4, 1),
                            IPAddress(255, 255, 255, 0));
   s_wm.setHostname(config::kPortalHostname);
+  s_wm.setCustomHeadElement(kRangeSelectScript);
   s_wm.setAPCallback(onConfigPortalApStarted);
   attachPortalParams(s_wm);
   s_wm_configured = true;

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -15,7 +15,6 @@
 #include "ui/radar_theme.h"
 #include "ui/runway_overlay.h"
 
-namespace fonts = lgfx::v1::fonts;
 
 namespace ui {
 namespace radar {

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -226,8 +226,12 @@ void latLonToScreen(float lat, float lon, int* out_x, int* out_y) {
   float dist_km = 0.0f;
   offsetKmFromCenter(lat, lon, &dx_km, &dy_km, &dist_km);
 
-  *out_x = radar::kCenterX + static_cast<int>(lroundf(dx_km * px_per_km));
-  *out_y = radar::kCenterY - static_cast<int>(lroundf(dy_km * px_per_km));
+  float screen_east = 0.0f;
+  float screen_north = 0.0f;
+  radar::rotateMapOffset(dx_km, dy_km, &screen_east, &screen_north);
+
+  *out_x = radar::kCenterX + static_cast<int>(lroundf(screen_east * px_per_km));
+  *out_y = radar::kCenterY - static_cast<int>(lroundf(screen_north * px_per_km));
 }
 
 bool isInsideOuterRingKm(float dist_km) { return dist_km <= innerRingMaxKm(); }
@@ -259,7 +263,10 @@ bool beyondRingEdgeDotFromLatLon(float lat, float lon, int* out_x, int* out_y) {
   const int cx = radar::kCenterX;
   const int cy = radar::kCenterY;
   const int rim_r = radar::kCenterX - radar::kBeyondRingScreenMarginPx;
-  const float angle_rad = atan2f(dx_km, dy_km);
+  float screen_east = 0.0f;
+  float screen_north = 0.0f;
+  radar::rotateMapOffset(dx_km, dy_km, &screen_east, &screen_north);
+  const float angle_rad = atan2f(screen_east, screen_north);
 
   *out_x = cx + static_cast<int>(lroundf(sinf(angle_rad) * rim_r));
   *out_y = cy - static_cast<int>(lroundf(cosf(angle_rad) * rim_r));
@@ -532,9 +539,11 @@ void drawAircraft() {
     const size_t i = items[d].index;
     const int x = items[d].x;
     const int y = items[d].y;
-    drawSpeedVector(x, y, planes[i].nose_deg, planes[i].track_deg,
+    drawSpeedVector(x, y, radar::headingToScreen(planes[i].nose_deg),
+                    radar::headingToScreen(planes[i].track_deg),
                     planes[i].gs_knots, radar::kColorTrackVector);
-    drawHeadingTriangle(x, y, planes[i].nose_deg, radar::kColorAircraft);
+    drawHeadingTriangle(x, y, radar::headingToScreen(planes[i].nose_deg),
+                        radar::kColorAircraft);
   }
   for (size_t d = 0; d < draw_count; ++d) {
     const size_t i = items[d].index;
@@ -615,13 +624,18 @@ void drawCenterDot(int cx, int cy) {
 void drawCardinalLabels() {
   const int cx = radar::kCenterX;
   const int cy = radar::kCenterY;
-  const int edge = radar::kSize - 1;
+  constexpr const char* kCardinals[] = {"N", "E", "S", "W"};
+  constexpr float kDegToRad = 0.01745329252f;
+  constexpr int kLabelRadius =
+      radar::kCenterX - radar::kCardinalLabelHeightPx / 2 + 1;
 
-  drawCardinalLabel("N", cx, radar::kCardinalNorthOffsetY, textdatum_t::top_center);
-  drawCardinalLabel("S", cx, edge + radar::kCardinalSouthOffsetY,
-                    textdatum_t::bottom_center);
-  drawCardinalLabel("W", 0, cy, textdatum_t::middle_left);
-  drawCardinalLabel("E", edge, cy, textdatum_t::middle_right);
+  for (size_t i = 0; i < 4; ++i) {
+    const float true_heading = static_cast<float>(i * 90U);
+    const float angle = radar::headingToScreen(true_heading) * kDegToRad;
+    const int x = cx + static_cast<int>(lroundf(sinf(angle) * kLabelRadius));
+    const int y = cy - static_cast<int>(lroundf(cosf(angle) * kLabelRadius));
+    drawCardinalLabel(kCardinals[i], x, y, textdatum_t::middle_center);
+  }
 }
 
 int scaleLabelAnchorX(int cx, int outer_radius) {

--- a/src/ui/radar_range.cpp
+++ b/src/ui/radar_range.cpp
@@ -4,6 +4,7 @@
 
 #include <Preferences.h>
 #include <cmath>
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 
@@ -15,7 +16,7 @@ constexpr char kPrefsNamespace[] = "planeradar";
 constexpr char kPrefsRangeKey[] = "rangeIdx";
 constexpr char kPrefsMilesKey[] = "useMiles";
 constexpr char kPrefsRunwaysKey[] = "showRwys";
-constexpr uint8_t kDefaultRangeIndex = 1;  // 10 km ring
+constexpr uint8_t kDefaultRangeIndex = 2;  // 10 km ring
 constexpr float kKmPerMile = 1.609344f;
 
 Preferences s_prefs;
@@ -81,6 +82,28 @@ void rangeNext() {
 const RangePreset& rangeCurrent() { return kRangePresets[s_range_index]; }
 
 uint8_t rangeIndex() { return s_range_index; }
+
+bool saveRangeFromPortal(const char* range_km_value) {
+  if (range_km_value == nullptr || range_km_value[0] == '\0') {
+    return false;
+  }
+
+  char* end = nullptr;
+  const float requested_km = strtof(range_km_value, &end);
+  if (end == range_km_value || *end != '\0') {
+    return false;
+  }
+
+  for (size_t i = 0; i < kRangePresetCount; ++i) {
+    if (fabsf(requested_km - kRangePresets[i].ring3_km) < 0.01f) {
+      s_range_index = static_cast<uint8_t>(i);
+      saveRangeIndex();
+      Serial.printf("Radar range: %.0f km\n", rangeCurrent().ring3_km);
+      return true;
+    }
+  }
+  return false;
+}
 
 float fetchRadiusKm() {
   const float outer_km = rangeCurrent().outer_km;

--- a/src/ui/radar_range.cpp
+++ b/src/ui/radar_range.cpp
@@ -16,6 +16,7 @@ constexpr char kPrefsNamespace[] = "planeradar";
 constexpr char kPrefsRangeKey[] = "rangeIdx";
 constexpr char kPrefsMilesKey[] = "useMiles";
 constexpr char kPrefsRunwaysKey[] = "showRwys";
+constexpr char kPrefsHeadingKey[] = "headingTop";
 constexpr uint8_t kDefaultRangeIndex = 2;  // 10 km ring
 constexpr float kKmPerMile = 1.609344f;
 
@@ -23,6 +24,11 @@ Preferences s_prefs;
 uint8_t s_range_index = kDefaultRangeIndex;
 bool s_use_miles = false;
 bool s_show_runways = true;
+uint16_t s_heading_at_top_deg = 0;
+
+bool validHeadingAtTop(uint16_t heading) {
+  return heading <= 359;
+}
 
 void saveRangeIndex() {
   if (!s_prefs.begin(kPrefsNamespace, false)) {
@@ -45,6 +51,14 @@ void saveShowRunways() {
     return;
   }
   s_prefs.putBool(kPrefsRunwaysKey, s_show_runways);
+  s_prefs.end();
+}
+
+void saveHeadingAtTop() {
+  if (!s_prefs.begin(kPrefsNamespace, false)) {
+    return;
+  }
+  s_prefs.putUShort(kPrefsHeadingKey, s_heading_at_top_deg);
   s_prefs.end();
 }
 
@@ -71,6 +85,8 @@ void rangeInit() {
       (saved < kRangePresetCount) ? saved : kDefaultRangeIndex;
   s_use_miles = s_prefs.getBool(kPrefsMilesKey, false);
   s_show_runways = s_prefs.getBool(kPrefsRunwaysKey, true);
+  const uint16_t saved_heading = s_prefs.getUShort(kPrefsHeadingKey, 0);
+  s_heading_at_top_deg = validHeadingAtTop(saved_heading) ? saved_heading : 0;
   s_prefs.end();
 }
 
@@ -116,6 +132,25 @@ bool useMiles() { return s_use_miles; }
 
 bool showRunways() { return s_show_runways; }
 
+uint16_t headingAtTopDeg() { return s_heading_at_top_deg; }
+
+void rotateMapOffset(float east, float north, float* screen_east,
+                     float* screen_north) {
+  constexpr float kDegToRad = 0.01745329252f;
+  const float angle = static_cast<float>(s_heading_at_top_deg) * kDegToRad;
+  const float sin_a = sinf(angle);
+  const float cos_a = cosf(angle);
+  *screen_east = east * cos_a - north * sin_a;
+  *screen_north = north * cos_a + east * sin_a;
+}
+
+float headingToScreen(float heading_deg) {
+  float rotated = heading_deg - static_cast<float>(s_heading_at_top_deg);
+  while (rotated < 0.0f) rotated += 360.0f;
+  while (rotated >= 360.0f) rotated -= 360.0f;
+  return rotated;
+}
+
 void saveMilesFromPortal(const char* checkbox_value) {
   s_use_miles = portalCheckboxChecked(checkbox_value);
   saveUseMiles();
@@ -126,6 +161,22 @@ void saveRunwaysFromPortal(const char* checkbox_value) {
   s_show_runways = portalCheckboxChecked(checkbox_value);
   saveShowRunways();
   Serial.printf("Runway overlay: %s\n", s_show_runways ? "on" : "off");
+}
+
+bool saveHeadingFromPortal(const char* heading_deg_value) {
+  if (heading_deg_value == nullptr || heading_deg_value[0] == '\0') {
+    return false;
+  }
+  char* end = nullptr;
+  const long heading = strtol(heading_deg_value, &end, 10);
+  if (end == heading_deg_value || *end != '\0' || heading < 0 || heading > 359 ||
+      !validHeadingAtTop(static_cast<uint16_t>(heading))) {
+    return false;
+  }
+  s_heading_at_top_deg = static_cast<uint16_t>(heading);
+  saveHeadingAtTop();
+  Serial.printf("Heading at top: %u degrees\n", s_heading_at_top_deg);
+  return true;
 }
 
 void formatRing3Label(char* buf, size_t len, float ring3_km, bool use_miles) {
@@ -145,9 +196,11 @@ void formatCurrentRing3Label(char* buf, size_t len) {
 void unitsReset() {
   s_use_miles = false;
   s_show_runways = true;
+  s_heading_at_top_deg = 0;
   if (s_prefs.begin(kPrefsNamespace, false)) {
     s_prefs.remove(kPrefsMilesKey);
     s_prefs.remove(kPrefsRunwaysKey);
+    s_prefs.remove(kPrefsHeadingKey);
     s_prefs.end();
   }
 }

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -11,7 +11,6 @@
 #include "ui/radar_range.h"
 #include "ui/radar_theme.h"
 
-namespace fonts = lgfx::v1::fonts;
 
 namespace ui::runway {
 namespace {

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -90,8 +90,12 @@ void latLonToScreen(float lat, float lon, int* out_x, int* out_y) {
   float dist_km = 0.0f;
   offsetKmFromCenter(lat, lon, &dx_km, &dy_km, &dist_km);
 
-  *out_x = radar::kCenterX + static_cast<int>(lroundf(dx_km * px_per_km));
-  *out_y = radar::kCenterY - static_cast<int>(lroundf(dy_km * px_per_km));
+  float screen_east = 0.0f;
+  float screen_north = 0.0f;
+  radar::rotateMapOffset(dx_km, dy_km, &screen_east, &screen_north);
+
+  *out_x = radar::kCenterX + static_cast<int>(lroundf(screen_east * px_per_km));
+  *out_y = radar::kCenterY - static_cast<int>(lroundf(screen_north * px_per_km));
 }
 
 int distSqFromCenter(int x, int y) {

--- a/src/ui/status_screens.cpp
+++ b/src/ui/status_screens.cpp
@@ -11,7 +11,6 @@
 #include "hardware/display.h"
 #include "hardware/display_font.h"
 
-namespace fonts = lgfx::v1::fonts;
 
 namespace {
 


### PR DESCRIPTION
## Summary

Adds configurable compass rotation so the radar display can be aligned with the direction the physical device is facing.

A new **Compass heading at top** setting accepts any whole degree from `0°` to `359°`. The selected heading is saved to flash and restored after restarting the device.

## Changes

- Add a **Compass heading at top** field to the setup page.
- Accept headings from `0°` through `359°`.
- Save the selected heading in ESP32 preferences.
- Use `0°` (north) as the default orientation.
- Rotate the following elements to match the selected heading:
  - N/E/S/W compass labels
  - Aircraft positions
  - Aircraft heading symbols
  - Track vectors
  - Beyond-range aircraft indicators
  - Runways
  - Airport labels
- Keep text upright while compass labels move around the display bezel.

## How to configure the heading

Enter the compass heading that should appear at the top of the radar display.

Examples:

- `0°` — north at the top
- `90°` — east at the top
- `180°` — south at the top
- `270°` — west at the top
- `112°` — east-southeast at the top

## Finding the heading with a smartphone

1. Place the ESP32 radar in its intended mounting position.
2. Open the compass app on your smartphone.
3. Hold the phone flat and level.
4. Align the top edge of the phone with the direction represented by the top of the radar display.
5. Keep the phone away from magnets, speakers, metal mounts, and powered electronics that could affect its compass.
6. Read the heading shown by the compass.
7. Open the radar’s setup page.
8. Enter that number in **Compass heading at top**.
9. Press **Save**.

For example, if the phone reads `112°` when its top edge is aligned with the top of the radar, enter `112`.

For the closest geographic alignment, configure the phone’s compass to use true north if that option is available. If the goal is simply to match what is seen through a window or from a fixed viewing position, using the displayed compass reading is usually sufficient.

## Testing

- Confirmed arbitrary headings from `0°` to `359°` are accepted.
- Confirmed the selected heading persists after saving.
- Confirmed compass labels rotate continuously around the bezel.
- Confirmed aircraft, vectors, runways, airport labels, and range indicators rotate consistently.
- Confirmed successful PlatformIO build for the `supermini` environment.