### PR TITLE
Feature/radar sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ During setup you can also hold BOOT at power-on to force a credential reset (sam
 **Reconfigure anytime** (after the device is on your network):
 
 1. Open **`http://plane-radar.local`** or **`http://<device-ip>`** (e.g. from your router or serial log at boot)
-2. Change Wi‑Fi, location, units, or runway overlay; save
+2. Change Wi‑Fi, location, units, runway overlay, or radar sweep; save
 
 The same portal runs on the setup AP and on the device’s LAN IP while connected to Wi‑Fi. mDNS hostname is `plane-radar` → **plane-radar.local** (`kPortalHostname` in `config.h`). Some clients resolve `.local` slowly; use the IP if needed.
 
@@ -44,6 +44,7 @@ The same portal runs on the setup AP and on the device’s LAN IP while connecte
 | **Latitude / Longitude** | Radar center and ADS-B query position (defaults in `config.h` until set) |
 | **Display distances in miles** | Ring scale label in **mi** instead of **km** (e.g. `6mi` vs `10km`) |
 | **Show airport runways** | Major-airport runway overlay on the radar (off to hide) |
+| **Show radar sweep** | Animated radar sweep (off also gives ADS-B fetching normal task priority) |
 
 After a reset, the device reboots and shows the setup screen immediately (no “Connecting” loop on stale credentials).
 

--- a/include/ui/radar_display.h
+++ b/include/ui/radar_display.h
@@ -8,4 +8,7 @@ void radarDisplayDraw();
 /** Redraw aircraft only (blits cached grid; no full-screen clear). */
 void radarDisplayRefreshAircraft();
 
+/** Advance the rotating sweep when its next animation frame is due. */
+void radarDisplayAnimate();
+
 }  // namespace ui

--- a/include/ui/radar_range.h
+++ b/include/ui/radar_range.h
@@ -49,9 +49,17 @@ float fetchRadiusKm();
 
 bool useMiles();
 bool showRunways();
+/** True heading, in degrees, displayed at the top of the radar. */
+uint16_t headingAtTopDeg();
+/** Rotate an east/north map offset into the configured screen orientation. */
+void rotateMapOffset(float east, float north, float* screen_east,
+                     float* screen_north);
+/** Convert a true heading to its clockwise screen-relative heading. */
+float headingToScreen(float heading_deg);
 /** WiFi portal checkbox: "T" = miles, otherwise km. */
 void saveMilesFromPortal(const char* checkbox_value);
 void saveRunwaysFromPortal(const char* checkbox_value);
+bool saveHeadingFromPortal(const char* heading_deg_value);
 void formatRing3Label(char* buf, size_t len, float ring3_km, bool use_miles);
 void formatCurrentRing3Label(char* buf, size_t len);
 /** Reset distance units to km (e.g. with WiFi credential wipe). */

--- a/include/ui/radar_range.h
+++ b/include/ui/radar_range.h
@@ -9,6 +9,7 @@ namespace ui::radar {
  * Range presets (label on ring 3 = ¾ of outer radius).
  *
  * Recommended for ADS-B on a 1.28″ display:
+ *   1 km  — high density areas
  *   5 km  — pattern / very local (airfield vicinity)
  *  10 km  — default; neighborhood spotting
  *  15 km  — wider local area
@@ -25,6 +26,7 @@ struct RangePreset {
 constexpr float kRing3ToOuterKm = 4.0f / 3.0f;
 
 constexpr RangePreset kRangePresets[] = {
+    {1.0f, 1.0f * kRing3ToOuterKm},
     {5.0f, 5.0f * kRing3ToOuterKm},
     {10.0f, 10.0f * kRing3ToOuterKm},
     {15.0f, 15.0f * kRing3ToOuterKm},
@@ -40,6 +42,8 @@ void rangeInit();
 void rangeNext();
 const RangePreset& rangeCurrent();
 uint8_t rangeIndex();
+/** Save a portal range value matching one of the configured ring-3 presets. */
+bool saveRangeFromPortal(const char* range_km_value);
 /** ADSB fetch radius (km): scaled to screen edge so beyond-ring dots have data. */
 float fetchRadiusKm();
 

--- a/include/ui/radar_range.h
+++ b/include/ui/radar_range.h
@@ -49,6 +49,7 @@ float fetchRadiusKm();
 
 bool useMiles();
 bool showRunways();
+bool sweepEnabled();
 /** True heading, in degrees, displayed at the top of the radar. */
 uint16_t headingAtTopDeg();
 /** Rotate an east/north map offset into the configured screen orientation. */
@@ -59,6 +60,7 @@ float headingToScreen(float heading_deg);
 /** WiFi portal checkbox: "T" = miles, otherwise km. */
 void saveMilesFromPortal(const char* checkbox_value);
 void saveRunwaysFromPortal(const char* checkbox_value);
+void saveSweepFromPortal(const char* checkbox_value);
 bool saveHeadingFromPortal(const char* heading_deg_value);
 void formatRing3Label(char* buf, size_t len, float ring3_km, bool use_miles);
 void formatCurrentRing3Label(char* buf, size_t len);

--- a/include/ui/radar_theme.h
+++ b/include/ui/radar_theme.h
@@ -31,6 +31,15 @@ constexpr float kGridStrokeHalfWidth = 1.0f;
 
 constexpr int kCenterDotRadius = 2;
 
+/** Clockwise sweep animation: one revolution and display update cadence. */
+constexpr unsigned long kSweepRevolutionMs = 3000;
+constexpr unsigned long kSweepFrameIntervalMs = 25;
+constexpr float kSweepStepDegrees = 3.0f;
+constexpr float kSweepLineHalfWidth = 1.0f;
+constexpr uint8_t kSweepR = 40;
+constexpr uint8_t kSweepG = 255;
+constexpr uint8_t kSweepB = 90;
+
 /** Filled aircraft symbol (nose triangle). */
 constexpr int kAircraftNoseLenPx = 8;
 constexpr int kAircraftTailLenPx = 3;
@@ -99,5 +108,6 @@ extern uint16_t kColorTagType;
 extern uint16_t kColorTagAltitude;
 extern uint16_t kColorRunway;
 extern uint16_t kColorRunwayLabel;
+extern uint16_t kColorSweep;
 
 }  // namespace ui::radar

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,9 @@ bool g_radar_visible = false;
 unsigned long g_wifi_down_since = 0;
 unsigned long g_last_reconnect_ms = 0;
 unsigned long g_last_adsb_fetch_ms = 0;
+volatile bool g_adsb_fetch_requested = false;
+volatile bool g_adsb_fetch_running = false;
+volatile bool g_adsb_refresh_ready = false;
 
 void showRadarIfConnected() {
   if (WiFi.status() != WL_CONNECTED) {
@@ -49,15 +52,22 @@ void handleBootButton() {
   }
 }
 
-void fetchAndDrawAircraft() {
-  const float fetch_km = ui::radar::fetchRadiusKm();
-  if (!services::adsb::fetchUpdate(services::location::lat(),
-                                   services::location::lon(), fetch_km)) {
-    handleBootButton();
-    return;
+void fetchAircraftTask(void*) {
+  for (;;) {
+    if (!g_adsb_fetch_requested) {
+      delay(10);
+      continue;
+    }
+    g_adsb_fetch_requested = false;
+    g_adsb_fetch_running = true;
+
+    const float fetch_km = ui::radar::fetchRadiusKm();
+    if (services::adsb::fetchUpdate(services::location::lat(),
+                                    services::location::lon(), fetch_km)) {
+      g_adsb_refresh_ready = true;
+    }
+    g_adsb_fetch_running = false;
   }
-  ui::radarDisplayRefreshAircraft();
-  handleBootButton();
 }
 
 }  // namespace
@@ -75,7 +85,11 @@ void setup() {
   }
   services::location::init();
   ui::radar::rangeInit();
-  services::adsb::setPollFn(wifiLoop);
+  services::adsb::setPollFn(nullptr);
+  if (xTaskCreate(fetchAircraftTask, "adsb-fetch", 8192, nullptr, 1,
+                  nullptr) != pdPASS) {
+    Serial.println("adsb: failed to create fetch task");
+  }
 
   if (wifiSetupConnect()) {
     showRadarIfConnected();
@@ -109,11 +123,21 @@ void loop() {
     g_wifi_down_since = 0;
     if (!g_radar_visible) {
       showRadarIfConnected();
-    } else if (millis() - g_last_adsb_fetch_ms >= config::kAdsbFetchIntervalMs) {
+    } else if (!g_adsb_fetch_running && !g_adsb_fetch_requested &&
+               millis() - g_last_adsb_fetch_ms >= config::kAdsbFetchIntervalMs) {
       g_last_adsb_fetch_ms = millis();
-      fetchAndDrawAircraft();
+      g_adsb_fetch_requested = true;
+    }
+    if (g_adsb_refresh_ready) {
+      g_adsb_refresh_ready = false;
+      ui::radarDisplayRefreshAircraft();
+    }
+    if (g_radar_visible) {
+      ui::radarDisplayAnimate();
     }
   }
 
-  delay(10);
+  // Keep animation cadence fine-grained; a 10 ms loop delay quantizes a
+  // requested 25 ms sweep interval into visibly uneven 30/40 ms steps.
+  delay(1);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,28 @@ unsigned long g_last_adsb_fetch_ms = 0;
 volatile bool g_adsb_fetch_requested = false;
 volatile bool g_adsb_fetch_running = false;
 volatile bool g_adsb_refresh_ready = false;
+TaskHandle_t g_adsb_fetch_task = nullptr;
+
+void fetchAircraftTask(void*);
+
+void syncAdsbFetchMode() {
+  if (ui::radar::sweepEnabled()) {
+    if (g_adsb_fetch_task == nullptr &&
+        xTaskCreate(fetchAircraftTask, "adsb-fetch", 8192, nullptr, 0,
+                    &g_adsb_fetch_task) != pdPASS) {
+      Serial.println("adsb: failed to create fetch task");
+    }
+    return;
+  }
+
+  if (g_adsb_fetch_task == nullptr || g_adsb_fetch_running ||
+      g_adsb_fetch_requested) {
+    return;
+  }
+  vTaskDelete(g_adsb_fetch_task);
+  g_adsb_fetch_task = nullptr;
+  Serial.println("ADS-B background task stopped (sweep off)");
+}
 
 void showRadarIfConnected() {
   if (WiFi.status() != WL_CONNECTED) {
@@ -70,6 +92,24 @@ void fetchAircraftTask(void*) {
   }
 }
 
+void pollDuringAdsbFetch() {
+  // The proven pre-sweep path keeps the portal responsive while synchronous
+  // networking is in progress. The background sweep path must not call the
+  // web server concurrently with the main loop.
+  if (!ui::radar::sweepEnabled() && !g_adsb_fetch_running) {
+    wifiLoop();
+  }
+}
+
+void fetchAndDrawAircraft() {
+  const float fetch_km = ui::radar::fetchRadiusKm();
+  if (services::adsb::fetchUpdate(services::location::lat(),
+                                  services::location::lon(), fetch_km)) {
+    ui::radarDisplayRefreshAircraft();
+  }
+  handleBootButton();
+}
+
 }  // namespace
 
 void setup() {
@@ -85,11 +125,8 @@ void setup() {
   }
   services::location::init();
   ui::radar::rangeInit();
-  services::adsb::setPollFn(nullptr);
-  if (xTaskCreate(fetchAircraftTask, "adsb-fetch", 8192, nullptr, 1,
-                  nullptr) != pdPASS) {
-    Serial.println("adsb: failed to create fetch task");
-  }
+  services::adsb::setPollFn(pollDuringAdsbFetch);
+  syncAdsbFetchMode();
 
   if (wifiSetupConnect()) {
     showRadarIfConnected();
@@ -99,6 +136,7 @@ void setup() {
 void loop() {
   handleBootButton();
   wifiLoop();
+  syncAdsbFetchMode();
 
   if (WiFi.status() != WL_CONNECTED) {
     if (g_radar_visible) {
@@ -126,7 +164,11 @@ void loop() {
     } else if (!g_adsb_fetch_running && !g_adsb_fetch_requested &&
                millis() - g_last_adsb_fetch_ms >= config::kAdsbFetchIntervalMs) {
       g_last_adsb_fetch_ms = millis();
-      g_adsb_fetch_requested = true;
+      if (ui::radar::sweepEnabled()) {
+        g_adsb_fetch_requested = true;
+      } else {
+        fetchAndDrawAircraft();
+      }
     }
     if (g_adsb_refresh_ready) {
       g_adsb_refresh_ready = false;

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -5,6 +5,7 @@
 
 #include <ArduinoJson.h>
 
+#include <algorithm>
 #include <cstring>
 
 #include "config.h"
@@ -18,8 +19,9 @@ constexpr float kKmPerNm = 1.852f;
 constexpr int kConnectAttemptMs = 200;
 constexpr unsigned long kRequestTimeoutMs = 10000;
 
-Aircraft s_aircraft[kMaxAircraft];
-size_t s_aircraft_count = 0;
+Aircraft s_aircraft[2][kMaxAircraft];
+size_t s_aircraft_count[2] = {0, 0};
+volatile uint8_t s_active_aircraft = 0;
 PollFn s_poll_fn = nullptr;
 
 void pollNetwork() {
@@ -27,6 +29,41 @@ void pollNetwork() {
     s_poll_fn();
   }
 }
+
+class PollingStreamReader {
+ public:
+  explicit PollingStreamReader(Stream& stream) : stream_(stream) {}
+
+  int read() {
+    char value = 0;
+    const bool received = stream_.readBytes(&value, 1) == 1;
+    pollOccasionally(1);
+    return received ? static_cast<unsigned char>(value) : -1;
+  }
+
+  size_t readBytes(char* buffer, size_t length) {
+    // Keep reads short so display animation is serviced while JSON arrives.
+    constexpr size_t kChunkSize = 256;
+    const size_t chunk = std::min(length, kChunkSize);
+    const size_t count = stream_.readBytes(buffer, chunk);
+    pollNetwork();
+    bytes_until_poll_ = kChunkSize;
+    return count;
+  }
+
+ private:
+  void pollOccasionally(size_t count) {
+    if (count >= bytes_until_poll_) {
+      pollNetwork();
+      bytes_until_poll_ = 256;
+    } else {
+      bytes_until_poll_ -= count;
+    }
+  }
+
+  Stream& stream_;
+  size_t bytes_until_poll_ = 256;
+};
 
 int performGetWithPoll(HTTPClient& http) {
   http.setConnectTimeout(kConnectAttemptMs);
@@ -180,11 +217,13 @@ void fillTagFields(Aircraft* ac, const JsonObject& plane) {
 
 void setPollFn(PollFn fn) { s_poll_fn = fn; }
 
-size_t aircraftCount() { return s_aircraft_count; }
+size_t aircraftCount() { return s_aircraft_count[s_active_aircraft]; }
 
-const Aircraft* aircraftList() { return s_aircraft; }
+const Aircraft* aircraftList() { return s_aircraft[s_active_aircraft]; }
 
 bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
+  const uint8_t update_index = static_cast<uint8_t>(1U - s_active_aircraft);
+  Aircraft* updated = s_aircraft[update_index];
   const float dist_nm = kmToNauticalMiles(fetch_radius_km);
 
   String url = kApiBase;
@@ -216,8 +255,9 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
   JsonDocument filter;
   buildAircraftJsonFilter(filter);
   JsonDocument doc;
-  const DeserializationError err = deserializeJson(
-      doc, http.getStream(), DeserializationOption::Filter(filter));
+  PollingStreamReader reader(http.getStream());
+  const DeserializationError err =
+      deserializeJson(doc, reader, DeserializationOption::Filter(filter));
   http.end();
   if (err) {
     Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
@@ -226,7 +266,8 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
 
   JsonArray ac = doc["ac"].as<JsonArray>();
   if (ac.isNull()) {
-    s_aircraft_count = 0;
+    s_aircraft_count[update_index] = 0;
+    s_active_aircraft = update_index;
     return true;
   }
 
@@ -242,16 +283,17 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
       continue;
     }
 
-    s_aircraft[n].lat = plane["lat"].as<float>();
-    s_aircraft[n].lon = plane["lon"].as<float>();
-    s_aircraft[n].nose_deg = pickNoseHeading(plane);
-    s_aircraft[n].track_deg = pickTrackHeading(plane);
-    s_aircraft[n].gs_knots = pickGroundSpeed(plane);
-    fillTagFields(&s_aircraft[n], plane);
+    updated[n].lat = plane["lat"].as<float>();
+    updated[n].lon = plane["lon"].as<float>();
+    updated[n].nose_deg = pickNoseHeading(plane);
+    updated[n].track_deg = pickTrackHeading(plane);
+    updated[n].gs_knots = pickGroundSpeed(plane);
+    fillTagFields(&updated[n], plane);
     ++n;
   }
 
-  s_aircraft_count = n;
+  s_aircraft_count[update_index] = n;
+  s_active_aircraft = update_index;
   Serial.printf("adsb: %u aircraft\n", static_cast<unsigned>(n));
   return true;
 }

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -46,46 +46,25 @@ int performGetWithPoll(HTTPClient& http) {
   return HTTPC_ERROR_READ_TIMEOUT;
 }
 
-bool readResponseBodyWithPoll(HTTPClient& http, String& payload) {
-  WiFiClient* stream = http.getStreamPtr();
-  if (stream == nullptr) {
-    return false;
-  }
-
-  const int content_length = http.getSize();
-  if (content_length > 0) {
-    payload.reserve(static_cast<unsigned>(content_length + 1));
-  }
-
-  uint8_t buffer[512];
-  const unsigned long deadline = millis() + kRequestTimeoutMs;
-  while (millis() < deadline) {
-    pollNetwork();
-    const int available = stream->available();
-    if (available > 0) {
-      const int to_read =
-          available > static_cast<int>(sizeof(buffer)) ? static_cast<int>(sizeof(buffer))
-                                                       : available;
-      const int read_bytes = stream->readBytes(buffer, to_read);
-      if (read_bytes > 0) {
-        payload.concat(reinterpret_cast<const char*>(buffer),
-                       static_cast<unsigned>(read_bytes));
-      }
-    }
-    if (content_length > 0 &&
-        static_cast<int>(payload.length()) >= content_length) {
-      break;
-    }
-    if (!http.connected() && stream->available() <= 0) {
-      break;
-    }
-    delay(1);
-  }
-
-  return payload.length() > 0;
-}
-
 float kmToNauticalMiles(float km) { return km / kKmPerNm; }
+
+void buildAircraftJsonFilter(JsonDocument& filter) {
+  JsonObject plane = filter["ac"][0].to<JsonObject>();
+  plane["lat"] = true;
+  plane["lon"] = true;
+  plane["true_heading"] = true;
+  plane["mag_heading"] = true;
+  plane["track"] = true;
+  plane["dir"] = true;
+  plane["gs"] = true;
+  plane["tas"] = true;
+  plane["ias"] = true;
+  plane["alt_baro"] = true;
+  plane["alt_geom"] = true;
+  plane["flight"] = true;
+  plane["hex"] = true;
+  plane["t"] = true;
+}
 
 bool readJsonFloat(const JsonObject& obj, const char* key, float* out) {
   if (obj[key].is<float>() || obj[key].is<double>() || obj[key].is<int>()) {
@@ -232,16 +211,14 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
     return false;
   }
 
-  String payload;
-  if (!readResponseBodyWithPoll(http, payload)) {
-    Serial.println("adsb: empty response");
-    http.end();
-    return false;
-  }
-  http.end();
-
+  // Parse directly from the network stream so large search radii do not need
+  // one contiguous response buffer. The filter retains only displayed fields.
+  JsonDocument filter;
+  buildAircraftJsonFilter(filter);
   JsonDocument doc;
-  const DeserializationError err = deserializeJson(doc, payload);
+  const DeserializationError err = deserializeJson(
+      doc, http.getStream(), DeserializationOption::Filter(filter));
+  http.end();
   if (err) {
     Serial.printf("adsb: JSON parse error: %s\n", err.c_str());
     return false;

--- a/src/services/adsb_client.cpp
+++ b/src/services/adsb_client.cpp
@@ -5,7 +5,6 @@
 
 #include <ArduinoJson.h>
 
-#include <algorithm>
 #include <cstring>
 
 #include "config.h"
@@ -29,41 +28,6 @@ void pollNetwork() {
     s_poll_fn();
   }
 }
-
-class PollingStreamReader {
- public:
-  explicit PollingStreamReader(Stream& stream) : stream_(stream) {}
-
-  int read() {
-    char value = 0;
-    const bool received = stream_.readBytes(&value, 1) == 1;
-    pollOccasionally(1);
-    return received ? static_cast<unsigned char>(value) : -1;
-  }
-
-  size_t readBytes(char* buffer, size_t length) {
-    // Keep reads short so display animation is serviced while JSON arrives.
-    constexpr size_t kChunkSize = 256;
-    const size_t chunk = std::min(length, kChunkSize);
-    const size_t count = stream_.readBytes(buffer, chunk);
-    pollNetwork();
-    bytes_until_poll_ = kChunkSize;
-    return count;
-  }
-
- private:
-  void pollOccasionally(size_t count) {
-    if (count >= bytes_until_poll_) {
-      pollNetwork();
-      bytes_until_poll_ = 256;
-    } else {
-      bytes_until_poll_ -= count;
-    }
-  }
-
-  Stream& stream_;
-  size_t bytes_until_poll_ = 256;
-};
 
 int performGetWithPoll(HTTPClient& http) {
   http.setConnectTimeout(kConnectAttemptMs);
@@ -255,9 +219,8 @@ bool fetchUpdate(double center_lat, double center_lon, float fetch_radius_km) {
   JsonDocument filter;
   buildAircraftJsonFilter(filter);
   JsonDocument doc;
-  PollingStreamReader reader(http.getStream());
-  const DeserializationError err =
-      deserializeJson(doc, reader, DeserializationOption::Filter(filter));
+  const DeserializationError err = deserializeJson(
+      doc, http.getStream(), DeserializationOption::Filter(filter));
   http.end();
   if (err) {
     Serial.printf("adsb: JSON parse error: %s\n", err.c_str());

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -119,6 +119,10 @@ char s_runways_checkbox_attrs[32] = "type=\"checkbox\"";
 WiFiManagerParameter s_param_runways("show_runways", "Show airport runways", "T", 2,
                                      s_runways_checkbox_attrs, WFM_LABEL_AFTER);
 
+char s_sweep_checkbox_attrs[32] = "type=\"checkbox\"";
+WiFiManagerParameter s_param_sweep("radar_sweep", "Show radar sweep", "T", 2,
+                                   s_sweep_checkbox_attrs, WFM_LABEL_AFTER);
+
 void refreshPortalParamDefaults() {
   char lat_buf[kCoordParamLen + 1];
   char lon_buf[kCoordParamLen + 1];
@@ -141,6 +145,9 @@ void refreshPortalParamDefaults() {
   snprintf(s_runways_checkbox_attrs, sizeof(s_runways_checkbox_attrs),
            "type=\"checkbox\"%s", ui::radar::showRunways() ? " checked" : "");
   s_param_runways.setValue("T", 2);
+  snprintf(s_sweep_checkbox_attrs, sizeof(s_sweep_checkbox_attrs),
+           "type=\"checkbox\"%s", ui::radar::sweepEnabled() ? " checked" : "");
+  s_param_sweep.setValue("T", 2);
 }
 
 void onPortalParamsSaved() {
@@ -150,7 +157,8 @@ void onPortalParamsSaved() {
       s_wm.server->hasArg("radar_range") ||
       s_wm.server->hasArg("heading_top") ||
       s_wm.server->hasArg("use_miles") ||
-      s_wm.server->hasArg("show_runways");
+      s_wm.server->hasArg("show_runways") ||
+      s_wm.server->hasArg("radar_sweep");
   if (!has_application_params) {
     // WiFiManager can invoke this callback again for a later portal request
     // that contains no application parameters. Its internal buffers have
@@ -171,6 +179,7 @@ void onPortalParamsSaved() {
   }
   ui::radar::saveMilesFromPortal(s_param_miles.getValue());
   ui::radar::saveRunwaysFromPortal(s_param_runways.getValue());
+  ui::radar::saveSweepFromPortal(s_param_sweep.getValue());
   refreshPortalParamDefaults();
 }
 
@@ -182,6 +191,7 @@ void attachPortalParams(WiFiManager& wm) {
   wm.addParameter(&s_param_heading);
   wm.addParameter(&s_param_miles);
   wm.addParameter(&s_param_runways);
+  wm.addParameter(&s_param_sweep);
   wm.setSaveParamsCallback(onPortalParamsSaved);
 }
 

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -69,26 +69,34 @@ bool wifiLinkUp();
 
 constexpr int kCoordParamLen = 20;
 constexpr int kRangeParamLen = 3;
+constexpr int kHeadingParamLen = 3;
 constexpr char kCoordInputAttrs[] =
     " type=\"number\" step=\"0.000001\"";
+constexpr char kHeadingInputAttrs[] =
+    " type=\"number\" min=\"0\" max=\"359\" step=\"1\" inputmode=\"numeric\"";
 
 constexpr char kRangeSelectScript[] = R"HTML(
 <script>
 document.addEventListener('DOMContentLoaded',function(){
-  var input=document.querySelector('input[name="radar_range"]');
-  if(!input)return;
-  var select=document.createElement('select');
-  select.name=input.name;
-  select.id=input.id;
-  select.style.cssText='width:100%;padding:8px;margin:8px 0 16px';
-  ['1','5','10','15','25'].forEach(function(value){
-    var option=document.createElement('option');
-    option.value=value;
-    option.textContent=value+' km';
-    option.selected=value===input.value;
-    select.appendChild(option);
-  });
-  input.replaceWith(select);
+  function makeSelect(name,options){
+    var input=document.querySelector('input[name="'+name+'"]');
+    if(!input)return;
+    var select=document.createElement('select');
+    select.name=input.name;
+    select.id=input.id;
+    select.style.cssText='width:100%;padding:8px;margin:8px 0 16px';
+    options.forEach(function(item){
+      var option=document.createElement('option');
+      option.value=item[0];
+      option.textContent=item[1];
+      option.selected=item[0]===input.value;
+      select.appendChild(option);
+    });
+    input.replaceWith(select);
+  }
+  makeSelect('radar_range',[
+    ['1','1 km'],['5','5 km'],['10','10 km'],['15','15 km'],['25','25 km']
+  ]);
 });
 </script>
 )HTML";
@@ -100,6 +108,8 @@ WiFiManagerParameter s_param_lon("radar_lon", "Longitude (deg)", "0",
 
 WiFiManagerParameter s_param_range("radar_range", "Radar range", "10",
                                   kRangeParamLen);
+WiFiManagerParameter s_param_heading("heading_top", "Compass heading at top",
+                                    "0", kHeadingParamLen, kHeadingInputAttrs);
 
 char s_miles_checkbox_attrs[32] = "type=\"checkbox\"";
 WiFiManagerParameter s_param_miles("use_miles", "Display distances in miles", "T", 2,
@@ -113,6 +123,7 @@ void refreshPortalParamDefaults() {
   char lat_buf[kCoordParamLen + 1];
   char lon_buf[kCoordParamLen + 1];
   char range_buf[kRangeParamLen + 1];
+  char heading_buf[kHeadingParamLen + 1];
   snprintf(lat_buf, sizeof(lat_buf), "%.6f", services::location::lat());
   snprintf(lon_buf, sizeof(lon_buf), "%.6f", services::location::lon());
   s_param_lat.setValue(lat_buf, kCoordParamLen);
@@ -120,6 +131,9 @@ void refreshPortalParamDefaults() {
   snprintf(range_buf, sizeof(range_buf), "%.0f",
            ui::radar::rangeCurrent().ring3_km);
   s_param_range.setValue(range_buf, kRangeParamLen);
+  snprintf(heading_buf, sizeof(heading_buf), "%u",
+           ui::radar::headingAtTopDeg());
+  s_param_heading.setValue(heading_buf, kHeadingParamLen);
   snprintf(s_miles_checkbox_attrs, sizeof(s_miles_checkbox_attrs),
            "type=\"checkbox\"%s",
            ui::radar::useMiles() ? " checked" : "");
@@ -134,6 +148,7 @@ void onPortalParamsSaved() {
       s_wm.server->hasArg("radar_lat") ||
       s_wm.server->hasArg("radar_lon") ||
       s_wm.server->hasArg("radar_range") ||
+      s_wm.server->hasArg("heading_top") ||
       s_wm.server->hasArg("use_miles") ||
       s_wm.server->hasArg("show_runways");
   if (!has_application_params) {
@@ -151,6 +166,9 @@ void onPortalParamsSaved() {
   if (!ui::radar::saveRangeFromPortal(s_param_range.getValue())) {
     Serial.println("Invalid radar range in portal — use 1, 5, 10, 15, or 25 km");
   }
+  if (!ui::radar::saveHeadingFromPortal(s_param_heading.getValue())) {
+    Serial.println("Invalid compass heading — use a degree value from 0 to 359");
+  }
   ui::radar::saveMilesFromPortal(s_param_miles.getValue());
   ui::radar::saveRunwaysFromPortal(s_param_runways.getValue());
   refreshPortalParamDefaults();
@@ -161,6 +179,7 @@ void attachPortalParams(WiFiManager& wm) {
   wm.addParameter(&s_param_lat);
   wm.addParameter(&s_param_lon);
   wm.addParameter(&s_param_range);
+  wm.addParameter(&s_param_heading);
   wm.addParameter(&s_param_miles);
   wm.addParameter(&s_param_runways);
   wm.setSaveParamsCallback(onPortalParamsSaved);

--- a/src/services/wifi_setup.cpp
+++ b/src/services/wifi_setup.cpp
@@ -68,13 +68,38 @@ void stopLanWebPortal();
 bool wifiLinkUp();
 
 constexpr int kCoordParamLen = 20;
+constexpr int kRangeParamLen = 3;
 constexpr char kCoordInputAttrs[] =
     " type=\"number\" step=\"0.000001\"";
+
+constexpr char kRangeSelectScript[] = R"HTML(
+<script>
+document.addEventListener('DOMContentLoaded',function(){
+  var input=document.querySelector('input[name="radar_range"]');
+  if(!input)return;
+  var select=document.createElement('select');
+  select.name=input.name;
+  select.id=input.id;
+  select.style.cssText='width:100%;padding:8px;margin:8px 0 16px';
+  ['1','5','10','15','25'].forEach(function(value){
+    var option=document.createElement('option');
+    option.value=value;
+    option.textContent=value+' km';
+    option.selected=value===input.value;
+    select.appendChild(option);
+  });
+  input.replaceWith(select);
+});
+</script>
+)HTML";
 
 WiFiManagerParameter s_param_lat("radar_lat", "Latitude (deg)", "0",
                                 kCoordParamLen, kCoordInputAttrs);
 WiFiManagerParameter s_param_lon("radar_lon", "Longitude (deg)", "0",
                                 kCoordParamLen, kCoordInputAttrs);
+
+WiFiManagerParameter s_param_range("radar_range", "Radar range", "10",
+                                  kRangeParamLen);
 
 char s_miles_checkbox_attrs[32] = "type=\"checkbox\"";
 WiFiManagerParameter s_param_miles("use_miles", "Display distances in miles", "T", 2,
@@ -87,11 +112,16 @@ WiFiManagerParameter s_param_runways("show_runways", "Show airport runways", "T"
 void refreshPortalParamDefaults() {
   char lat_buf[kCoordParamLen + 1];
   char lon_buf[kCoordParamLen + 1];
+  char range_buf[kRangeParamLen + 1];
   snprintf(lat_buf, sizeof(lat_buf), "%.6f", services::location::lat());
   snprintf(lon_buf, sizeof(lon_buf), "%.6f", services::location::lon());
   s_param_lat.setValue(lat_buf, kCoordParamLen);
   s_param_lon.setValue(lon_buf, kCoordParamLen);
-  snprintf(s_miles_checkbox_attrs, sizeof(s_miles_checkbox_attrs), "type=\"checkbox\"%s",
+  snprintf(range_buf, sizeof(range_buf), "%.0f",
+           ui::radar::rangeCurrent().ring3_km);
+  s_param_range.setValue(range_buf, kRangeParamLen);
+  snprintf(s_miles_checkbox_attrs, sizeof(s_miles_checkbox_attrs),
+           "type=\"checkbox\"%s",
            ui::radar::useMiles() ? " checked" : "");
   s_param_miles.setValue("T", 2);
   snprintf(s_runways_checkbox_attrs, sizeof(s_runways_checkbox_attrs),
@@ -100,18 +130,37 @@ void refreshPortalParamDefaults() {
 }
 
 void onPortalParamsSaved() {
+  const bool has_application_params =
+      s_wm.server->hasArg("radar_lat") ||
+      s_wm.server->hasArg("radar_lon") ||
+      s_wm.server->hasArg("radar_range") ||
+      s_wm.server->hasArg("use_miles") ||
+      s_wm.server->hasArg("show_runways");
+  if (!has_application_params) {
+    // WiFiManager can invoke this callback again for a later portal request
+    // that contains no application parameters. Its internal buffers have
+    // already been cleared at this point, so restore them without saving.
+    refreshPortalParamDefaults();
+    return;
+  }
+
   if (!services::location::saveFromStrings(s_param_lat.getValue(),
                                            s_param_lon.getValue())) {
     Serial.println("Invalid lat/lon in portal — keeping previous location");
   }
+  if (!ui::radar::saveRangeFromPortal(s_param_range.getValue())) {
+    Serial.println("Invalid radar range in portal — use 1, 5, 10, 15, or 25 km");
+  }
   ui::radar::saveMilesFromPortal(s_param_miles.getValue());
   ui::radar::saveRunwaysFromPortal(s_param_runways.getValue());
+  refreshPortalParamDefaults();
 }
 
 void attachPortalParams(WiFiManager& wm) {
   refreshPortalParamDefaults();
   wm.addParameter(&s_param_lat);
   wm.addParameter(&s_param_lon);
+  wm.addParameter(&s_param_range);
   wm.addParameter(&s_param_miles);
   wm.addParameter(&s_param_runways);
   wm.setSaveParamsCallback(onPortalParamsSaved);
@@ -223,6 +272,7 @@ void ensureWifiManager() {
   s_wm.setAPStaticIPConfig(IPAddress(192, 168, 4, 1), IPAddress(192, 168, 4, 1),
                            IPAddress(255, 255, 255, 0));
   s_wm.setHostname(config::kPortalHostname);
+  s_wm.setCustomHeadElement(kRangeSelectScript);
   s_wm.setAPCallback(onConfigPortalApStarted);
   attachPortalParams(s_wm);
   s_wm_configured = true;

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -15,7 +15,6 @@
 #include "ui/radar_theme.h"
 #include "ui/runway_overlay.h"
 
-namespace fonts = lgfx::v1::fonts;
 
 namespace ui {
 namespace radar {

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -226,8 +226,12 @@ void latLonToScreen(float lat, float lon, int* out_x, int* out_y) {
   float dist_km = 0.0f;
   offsetKmFromCenter(lat, lon, &dx_km, &dy_km, &dist_km);
 
-  *out_x = radar::kCenterX + static_cast<int>(lroundf(dx_km * px_per_km));
-  *out_y = radar::kCenterY - static_cast<int>(lroundf(dy_km * px_per_km));
+  float screen_east = 0.0f;
+  float screen_north = 0.0f;
+  radar::rotateMapOffset(dx_km, dy_km, &screen_east, &screen_north);
+
+  *out_x = radar::kCenterX + static_cast<int>(lroundf(screen_east * px_per_km));
+  *out_y = radar::kCenterY - static_cast<int>(lroundf(screen_north * px_per_km));
 }
 
 bool isInsideOuterRingKm(float dist_km) { return dist_km <= innerRingMaxKm(); }
@@ -259,7 +263,10 @@ bool beyondRingEdgeDotFromLatLon(float lat, float lon, int* out_x, int* out_y) {
   const int cx = radar::kCenterX;
   const int cy = radar::kCenterY;
   const int rim_r = radar::kCenterX - radar::kBeyondRingScreenMarginPx;
-  const float angle_rad = atan2f(dx_km, dy_km);
+  float screen_east = 0.0f;
+  float screen_north = 0.0f;
+  radar::rotateMapOffset(dx_km, dy_km, &screen_east, &screen_north);
+  const float angle_rad = atan2f(screen_east, screen_north);
 
   *out_x = cx + static_cast<int>(lroundf(sinf(angle_rad) * rim_r));
   *out_y = cy - static_cast<int>(lroundf(cosf(angle_rad) * rim_r));
@@ -532,9 +539,11 @@ void drawAircraft() {
     const size_t i = items[d].index;
     const int x = items[d].x;
     const int y = items[d].y;
-    drawSpeedVector(x, y, planes[i].nose_deg, planes[i].track_deg,
+    drawSpeedVector(x, y, radar::headingToScreen(planes[i].nose_deg),
+                    radar::headingToScreen(planes[i].track_deg),
                     planes[i].gs_knots, radar::kColorTrackVector);
-    drawHeadingTriangle(x, y, planes[i].nose_deg, radar::kColorAircraft);
+    drawHeadingTriangle(x, y, radar::headingToScreen(planes[i].nose_deg),
+                        radar::kColorAircraft);
   }
   for (size_t d = 0; d < draw_count; ++d) {
     const size_t i = items[d].index;
@@ -615,13 +624,18 @@ void drawCenterDot(int cx, int cy) {
 void drawCardinalLabels() {
   const int cx = radar::kCenterX;
   const int cy = radar::kCenterY;
-  const int edge = radar::kSize - 1;
+  constexpr const char* kCardinals[] = {"N", "E", "S", "W"};
+  constexpr float kDegToRad = 0.01745329252f;
+  constexpr int kLabelRadius =
+      radar::kCenterX - radar::kCardinalLabelHeightPx / 2 + 1;
 
-  drawCardinalLabel("N", cx, radar::kCardinalNorthOffsetY, textdatum_t::top_center);
-  drawCardinalLabel("S", cx, edge + radar::kCardinalSouthOffsetY,
-                    textdatum_t::bottom_center);
-  drawCardinalLabel("W", 0, cy, textdatum_t::middle_left);
-  drawCardinalLabel("E", edge, cy, textdatum_t::middle_right);
+  for (size_t i = 0; i < 4; ++i) {
+    const float true_heading = static_cast<float>(i * 90U);
+    const float angle = radar::headingToScreen(true_heading) * kDegToRad;
+    const int x = cx + static_cast<int>(lroundf(sinf(angle) * kLabelRadius));
+    const int y = cy - static_cast<int>(lroundf(cosf(angle) * kLabelRadius));
+    drawCardinalLabel(kCardinals[i], x, y, textdatum_t::middle_center);
+  }
 }
 
 int scaleLabelAnchorX(int cx, int outer_radius) {

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <cstdlib>
 
 #include "config.h"
@@ -29,6 +30,7 @@ uint16_t kColorTagType = 0x5DFF;
 uint16_t kColorTagAltitude = 0xFFE0;
 uint16_t kColorRunway = 0x4D5F;
 uint16_t kColorRunwayLabel = 0x7DFF;
+uint16_t kColorSweep = 0x07E0;
 
 }  // namespace radar
 
@@ -53,6 +55,9 @@ int s_scale_label_h = 0;
 lgfx::LovyanGFX* s_draw = &tft;
 LGFX_Sprite s_frame(&tft);
 bool s_frame_ready = false;
+unsigned long s_last_sweep_frame_ms = 0;
+float s_previous_sweep_deg = 0.0f;
+bool s_previous_sweep_valid = false;
 
 class DrawScope {
  public:
@@ -196,6 +201,8 @@ void initPalette() {
       tft.color565(radar::kRunwayR, radar::kRunwayG, radar::kRunwayB);
   radar::kColorRunwayLabel = tft.color565(radar::kRunwayLabelR, radar::kRunwayLabelG,
                                           radar::kRunwayLabelB);
+  radar::kColorSweep =
+      tft.color565(radar::kSweepR, radar::kSweepG, radar::kSweepB);
 }
 
 constexpr float kKmPerDeg = 111.0f;
@@ -621,6 +628,23 @@ void drawCenterDot(int cx, int cy) {
   s_draw->fillSmoothCircle(cx, cy, radar::kCenterDotRadius, radar::kColorCenter);
 }
 
+float sweepHeadingDeg(unsigned long now) {
+  const unsigned long phase_ms = now % radar::kSweepRevolutionMs;
+  return 360.0f * static_cast<float>(phase_ms) /
+         radar::kSweepRevolutionMs;
+}
+
+void drawSweep(float head_deg) {
+  constexpr float kDegToRad = 0.01745329252f;
+  const float angle = head_deg * kDegToRad;
+  const int x = radar::kCenterX + static_cast<int>(
+      lroundf(sinf(angle) * radar::kGridOuterRadius));
+  const int y = radar::kCenterY - static_cast<int>(
+      lroundf(cosf(angle) * radar::kGridOuterRadius));
+  s_draw->drawWideLine(radar::kCenterX, radar::kCenterY, x, y,
+                       radar::kSweepLineHalfWidth, radar::kColorSweep);
+}
+
 void drawCardinalLabels() {
   const int cx = radar::kCenterX;
   const int cy = radar::kCenterY;
@@ -673,6 +697,8 @@ bool ensureFrameSprite() {
   if (s_frame_ready) {
     return true;
   }
+  // The cached radar remains RGB565 so aircraft, labels, and runway colors use
+  // the exact same rendering path and color depth as a non-animated frame.
   s_frame.setColorDepth(16);
   if (!s_frame.createSprite(radar::kSize, radar::kSize)) {
     Serial.println("radar: frame sprite alloc failed");
@@ -685,14 +711,45 @@ bool ensureFrameSprite() {
 // Double-buffered frame: composite the grid AND aircraft into the off-screen
 // sprite, then blit it to the panel in a single pushSprite. Because the panel
 // is updated in one pass, labels never show an erase/redraw gap — no flicker.
-void renderFrame() {
+void renderBaseFrame() {
   drawStaticGrid(s_frame);  // opens its own DrawScope(s_frame)
   {
     const DrawScope scope(s_frame);
     drawAircraft();
   }
-  s_frame.pushSprite(0, 0);
-  tft.setTextDatum(textdatum_t::top_left);
+}
+
+void restoreSweepLine(float angle_deg) {
+  if (!s_frame_ready) {
+    return;
+  }
+
+  constexpr float kDegToRad = 0.01745329252f;
+  const float angle = angle_deg * kDegToRad;
+  const int x0 = radar::kCenterX;
+  const int y0 = radar::kCenterY;
+  const int x1 = radar::kCenterX + static_cast<int>(
+      lroundf(sinf(angle) * radar::kGridOuterRadius));
+  const int y1 = radar::kCenterY - static_cast<int>(
+      lroundf(cosf(angle) * radar::kGridOuterRadius));
+
+  // Restore a padded rectangle through LovyanGFX's conversion path. Reading
+  // the raw sprite buffer directly is unsafe because its RGB565 byte order can
+  // differ from the panel's expected write order.
+  constexpr int kPadding = 3;
+  const int left = std::max(0, std::min(x0, x1) - kPadding);
+  const int top = std::max(0, std::min(y0, y1) - kPadding);
+  const int right =
+      std::min(radar::kSize - 1, std::max(x0, x1) + kPadding);
+  const int bottom =
+      std::min(radar::kSize - 1, std::max(y0, y1) + kPadding);
+  const int width = right - left + 1;
+
+  uint16_t row_pixels[radar::kSize];
+  for (int y = top; y <= bottom; ++y) {
+    s_frame.readRect(left, y, width, 1, row_pixels);
+    tft.pushImage(left, y, width, 1, row_pixels);
+  }
 }
 
 }  // namespace
@@ -700,24 +757,75 @@ void renderFrame() {
 void radarDisplayDraw() {
   initPalette();
   initLabelMetrics();
+  s_last_sweep_frame_ms = millis();
+  const float sweep_deg = sweepHeadingDeg(s_last_sweep_frame_ms);
+  s_previous_sweep_deg = sweep_deg;
 
   if (ensureFrameSprite()) {
-    renderFrame();
+    renderBaseFrame();
+    s_frame.pushSprite(0, 0);
+    {
+      const DrawScope scope(tft);
+      drawSweep(sweep_deg);
+    }
+    s_previous_sweep_valid = true;
     return;
   }
 
   // Fallback when the sprite can't be allocated: draw straight to the panel.
   const DrawScope scope(tft);
   drawStaticGrid(tft);
+  drawSweep(sweep_deg);
   drawAircraft();
   tft.setTextDatum(textdatum_t::top_left);
 }
 
 void radarDisplayRefreshAircraft() {
   initPalette();
+  s_last_sweep_frame_ms = millis();
+  // Aircraft updates arrive on roughly the same cadence as one revolution.
+  // Preserve the current fixed-step angle so a network completion cannot jump
+  // the beam forward and permanently skip a sector of the circle.
+  const float sweep_deg = s_previous_sweep_valid
+                              ? s_previous_sweep_deg
+                              : sweepHeadingDeg(s_last_sweep_frame_ms);
+  s_previous_sweep_deg = sweep_deg;
 
   if (ensureFrameSprite()) {
-    renderFrame();
+    renderBaseFrame();
+    s_frame.pushSprite(0, 0);
+    {
+      const DrawScope scope(tft);
+      drawSweep(sweep_deg);
+    }
+    s_previous_sweep_valid = true;
+    return;
+  }
+
+  radarDisplayDraw();
+}
+
+void radarDisplayAnimate() {
+  const unsigned long now = millis();
+  if (now - s_last_sweep_frame_ms < radar::kSweepFrameIntervalMs) {
+    return;
+  }
+  s_last_sweep_frame_ms = now;
+  float sweep_deg = s_previous_sweep_deg + radar::kSweepStepDegrees;
+  if (sweep_deg >= 360.0f) {
+    sweep_deg -= 360.0f;
+  }
+
+  if (ensureFrameSprite()) {
+    if (s_previous_sweep_valid) {
+      restoreSweepLine(s_previous_sweep_deg);
+    }
+    {
+      const DrawScope scope(tft);
+      drawSweep(sweep_deg);
+    }
+    s_previous_sweep_deg = sweep_deg;
+    s_previous_sweep_valid = true;
     return;
   }
 

--- a/src/ui/radar_display.cpp
+++ b/src/ui/radar_display.cpp
@@ -764,18 +764,20 @@ void radarDisplayDraw() {
   if (ensureFrameSprite()) {
     renderBaseFrame();
     s_frame.pushSprite(0, 0);
-    {
+    if (radar::sweepEnabled()) {
       const DrawScope scope(tft);
       drawSweep(sweep_deg);
     }
-    s_previous_sweep_valid = true;
+    s_previous_sweep_valid = radar::sweepEnabled();
     return;
   }
 
   // Fallback when the sprite can't be allocated: draw straight to the panel.
   const DrawScope scope(tft);
   drawStaticGrid(tft);
-  drawSweep(sweep_deg);
+  if (radar::sweepEnabled()) {
+    drawSweep(sweep_deg);
+  }
   drawAircraft();
   tft.setTextDatum(textdatum_t::top_left);
 }
@@ -794,11 +796,11 @@ void radarDisplayRefreshAircraft() {
   if (ensureFrameSprite()) {
     renderBaseFrame();
     s_frame.pushSprite(0, 0);
-    {
+    if (radar::sweepEnabled()) {
       const DrawScope scope(tft);
       drawSweep(sweep_deg);
     }
-    s_previous_sweep_valid = true;
+    s_previous_sweep_valid = radar::sweepEnabled();
     return;
   }
 
@@ -807,11 +809,20 @@ void radarDisplayRefreshAircraft() {
 
 void radarDisplayAnimate() {
   const unsigned long now = millis();
+  if (!radar::sweepEnabled()) {
+    if (s_previous_sweep_valid && ensureFrameSprite()) {
+      restoreSweepLine(s_previous_sweep_deg);
+    }
+    s_previous_sweep_valid = false;
+    return;
+  }
   if (now - s_last_sweep_frame_ms < radar::kSweepFrameIntervalMs) {
     return;
   }
   s_last_sweep_frame_ms = now;
-  float sweep_deg = s_previous_sweep_deg + radar::kSweepStepDegrees;
+  float sweep_deg = s_previous_sweep_valid
+                        ? s_previous_sweep_deg + radar::kSweepStepDegrees
+                        : sweepHeadingDeg(now);
   if (sweep_deg >= 360.0f) {
     sweep_deg -= 360.0f;
   }

--- a/src/ui/radar_range.cpp
+++ b/src/ui/radar_range.cpp
@@ -16,6 +16,9 @@ constexpr char kPrefsNamespace[] = "planeradar";
 constexpr char kPrefsRangeKey[] = "rangeIdx";
 constexpr char kPrefsMilesKey[] = "useMiles";
 constexpr char kPrefsRunwaysKey[] = "showRwys";
+// New key intentionally ignores the earlier experimental sweep-on value so
+// devices testing pre-release builds also start with the new off default.
+constexpr char kPrefsSweepKey[] = "sweepOn";
 constexpr char kPrefsHeadingKey[] = "headingTop";
 constexpr uint8_t kDefaultRangeIndex = 2;  // 10 km ring
 constexpr float kKmPerMile = 1.609344f;
@@ -24,6 +27,7 @@ Preferences s_prefs;
 uint8_t s_range_index = kDefaultRangeIndex;
 bool s_use_miles = false;
 bool s_show_runways = true;
+bool s_sweep_enabled = false;
 uint16_t s_heading_at_top_deg = 0;
 
 bool validHeadingAtTop(uint16_t heading) {
@@ -51,6 +55,14 @@ void saveShowRunways() {
     return;
   }
   s_prefs.putBool(kPrefsRunwaysKey, s_show_runways);
+  s_prefs.end();
+}
+
+void saveSweepEnabled() {
+  if (!s_prefs.begin(kPrefsNamespace, false)) {
+    return;
+  }
+  s_prefs.putBool(kPrefsSweepKey, s_sweep_enabled);
   s_prefs.end();
 }
 
@@ -85,6 +97,7 @@ void rangeInit() {
       (saved < kRangePresetCount) ? saved : kDefaultRangeIndex;
   s_use_miles = s_prefs.getBool(kPrefsMilesKey, false);
   s_show_runways = s_prefs.getBool(kPrefsRunwaysKey, true);
+  s_sweep_enabled = s_prefs.getBool(kPrefsSweepKey, false);
   const uint16_t saved_heading = s_prefs.getUShort(kPrefsHeadingKey, 0);
   s_heading_at_top_deg = validHeadingAtTop(saved_heading) ? saved_heading : 0;
   s_prefs.end();
@@ -132,6 +145,8 @@ bool useMiles() { return s_use_miles; }
 
 bool showRunways() { return s_show_runways; }
 
+bool sweepEnabled() { return s_sweep_enabled; }
+
 uint16_t headingAtTopDeg() { return s_heading_at_top_deg; }
 
 void rotateMapOffset(float east, float north, float* screen_east,
@@ -161,6 +176,12 @@ void saveRunwaysFromPortal(const char* checkbox_value) {
   s_show_runways = portalCheckboxChecked(checkbox_value);
   saveShowRunways();
   Serial.printf("Runway overlay: %s\n", s_show_runways ? "on" : "off");
+}
+
+void saveSweepFromPortal(const char* checkbox_value) {
+  s_sweep_enabled = portalCheckboxChecked(checkbox_value);
+  saveSweepEnabled();
+  Serial.printf("Radar sweep: %s\n", s_sweep_enabled ? "on" : "off");
 }
 
 bool saveHeadingFromPortal(const char* heading_deg_value) {
@@ -196,10 +217,12 @@ void formatCurrentRing3Label(char* buf, size_t len) {
 void unitsReset() {
   s_use_miles = false;
   s_show_runways = true;
+  s_sweep_enabled = false;
   s_heading_at_top_deg = 0;
   if (s_prefs.begin(kPrefsNamespace, false)) {
     s_prefs.remove(kPrefsMilesKey);
     s_prefs.remove(kPrefsRunwaysKey);
+    s_prefs.remove(kPrefsSweepKey);
     s_prefs.remove(kPrefsHeadingKey);
     s_prefs.end();
   }

--- a/src/ui/radar_range.cpp
+++ b/src/ui/radar_range.cpp
@@ -4,6 +4,7 @@
 
 #include <Preferences.h>
 #include <cmath>
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 
@@ -15,7 +16,7 @@ constexpr char kPrefsNamespace[] = "planeradar";
 constexpr char kPrefsRangeKey[] = "rangeIdx";
 constexpr char kPrefsMilesKey[] = "useMiles";
 constexpr char kPrefsRunwaysKey[] = "showRwys";
-constexpr uint8_t kDefaultRangeIndex = 1;  // 10 km ring
+constexpr uint8_t kDefaultRangeIndex = 2;  // 10 km ring
 constexpr float kKmPerMile = 1.609344f;
 
 Preferences s_prefs;
@@ -81,6 +82,28 @@ void rangeNext() {
 const RangePreset& rangeCurrent() { return kRangePresets[s_range_index]; }
 
 uint8_t rangeIndex() { return s_range_index; }
+
+bool saveRangeFromPortal(const char* range_km_value) {
+  if (range_km_value == nullptr || range_km_value[0] == '\0') {
+    return false;
+  }
+
+  char* end = nullptr;
+  const float requested_km = strtof(range_km_value, &end);
+  if (end == range_km_value || *end != '\0') {
+    return false;
+  }
+
+  for (size_t i = 0; i < kRangePresetCount; ++i) {
+    if (fabsf(requested_km - kRangePresets[i].ring3_km) < 0.01f) {
+      s_range_index = static_cast<uint8_t>(i);
+      saveRangeIndex();
+      Serial.printf("Radar range: %.0f km\n", rangeCurrent().ring3_km);
+      return true;
+    }
+  }
+  return false;
+}
 
 float fetchRadiusKm() {
   const float outer_km = rangeCurrent().outer_km;

--- a/src/ui/radar_range.cpp
+++ b/src/ui/radar_range.cpp
@@ -16,6 +16,7 @@ constexpr char kPrefsNamespace[] = "planeradar";
 constexpr char kPrefsRangeKey[] = "rangeIdx";
 constexpr char kPrefsMilesKey[] = "useMiles";
 constexpr char kPrefsRunwaysKey[] = "showRwys";
+constexpr char kPrefsHeadingKey[] = "headingTop";
 constexpr uint8_t kDefaultRangeIndex = 2;  // 10 km ring
 constexpr float kKmPerMile = 1.609344f;
 
@@ -23,6 +24,11 @@ Preferences s_prefs;
 uint8_t s_range_index = kDefaultRangeIndex;
 bool s_use_miles = false;
 bool s_show_runways = true;
+uint16_t s_heading_at_top_deg = 0;
+
+bool validHeadingAtTop(uint16_t heading) {
+  return heading <= 359;
+}
 
 void saveRangeIndex() {
   if (!s_prefs.begin(kPrefsNamespace, false)) {
@@ -45,6 +51,14 @@ void saveShowRunways() {
     return;
   }
   s_prefs.putBool(kPrefsRunwaysKey, s_show_runways);
+  s_prefs.end();
+}
+
+void saveHeadingAtTop() {
+  if (!s_prefs.begin(kPrefsNamespace, false)) {
+    return;
+  }
+  s_prefs.putUShort(kPrefsHeadingKey, s_heading_at_top_deg);
   s_prefs.end();
 }
 
@@ -71,6 +85,8 @@ void rangeInit() {
       (saved < kRangePresetCount) ? saved : kDefaultRangeIndex;
   s_use_miles = s_prefs.getBool(kPrefsMilesKey, false);
   s_show_runways = s_prefs.getBool(kPrefsRunwaysKey, true);
+  const uint16_t saved_heading = s_prefs.getUShort(kPrefsHeadingKey, 0);
+  s_heading_at_top_deg = validHeadingAtTop(saved_heading) ? saved_heading : 0;
   s_prefs.end();
 }
 
@@ -116,6 +132,25 @@ bool useMiles() { return s_use_miles; }
 
 bool showRunways() { return s_show_runways; }
 
+uint16_t headingAtTopDeg() { return s_heading_at_top_deg; }
+
+void rotateMapOffset(float east, float north, float* screen_east,
+                     float* screen_north) {
+  constexpr float kDegToRad = 0.01745329252f;
+  const float angle = static_cast<float>(s_heading_at_top_deg) * kDegToRad;
+  const float sin_a = sinf(angle);
+  const float cos_a = cosf(angle);
+  *screen_east = east * cos_a - north * sin_a;
+  *screen_north = north * cos_a + east * sin_a;
+}
+
+float headingToScreen(float heading_deg) {
+  float rotated = heading_deg - static_cast<float>(s_heading_at_top_deg);
+  while (rotated < 0.0f) rotated += 360.0f;
+  while (rotated >= 360.0f) rotated -= 360.0f;
+  return rotated;
+}
+
 void saveMilesFromPortal(const char* checkbox_value) {
   s_use_miles = portalCheckboxChecked(checkbox_value);
   saveUseMiles();
@@ -126,6 +161,22 @@ void saveRunwaysFromPortal(const char* checkbox_value) {
   s_show_runways = portalCheckboxChecked(checkbox_value);
   saveShowRunways();
   Serial.printf("Runway overlay: %s\n", s_show_runways ? "on" : "off");
+}
+
+bool saveHeadingFromPortal(const char* heading_deg_value) {
+  if (heading_deg_value == nullptr || heading_deg_value[0] == '\0') {
+    return false;
+  }
+  char* end = nullptr;
+  const long heading = strtol(heading_deg_value, &end, 10);
+  if (end == heading_deg_value || *end != '\0' || heading < 0 || heading > 359 ||
+      !validHeadingAtTop(static_cast<uint16_t>(heading))) {
+    return false;
+  }
+  s_heading_at_top_deg = static_cast<uint16_t>(heading);
+  saveHeadingAtTop();
+  Serial.printf("Heading at top: %u degrees\n", s_heading_at_top_deg);
+  return true;
 }
 
 void formatRing3Label(char* buf, size_t len, float ring3_km, bool use_miles) {
@@ -145,9 +196,11 @@ void formatCurrentRing3Label(char* buf, size_t len) {
 void unitsReset() {
   s_use_miles = false;
   s_show_runways = true;
+  s_heading_at_top_deg = 0;
   if (s_prefs.begin(kPrefsNamespace, false)) {
     s_prefs.remove(kPrefsMilesKey);
     s_prefs.remove(kPrefsRunwaysKey);
+    s_prefs.remove(kPrefsHeadingKey);
     s_prefs.end();
   }
 }

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -11,7 +11,6 @@
 #include "ui/radar_range.h"
 #include "ui/radar_theme.h"
 
-namespace fonts = lgfx::v1::fonts;
 
 namespace ui::runway {
 namespace {

--- a/src/ui/runway_overlay.cpp
+++ b/src/ui/runway_overlay.cpp
@@ -90,8 +90,12 @@ void latLonToScreen(float lat, float lon, int* out_x, int* out_y) {
   float dist_km = 0.0f;
   offsetKmFromCenter(lat, lon, &dx_km, &dy_km, &dist_km);
 
-  *out_x = radar::kCenterX + static_cast<int>(lroundf(dx_km * px_per_km));
-  *out_y = radar::kCenterY - static_cast<int>(lroundf(dy_km * px_per_km));
+  float screen_east = 0.0f;
+  float screen_north = 0.0f;
+  radar::rotateMapOffset(dx_km, dy_km, &screen_east, &screen_north);
+
+  *out_x = radar::kCenterX + static_cast<int>(lroundf(screen_east * px_per_km));
+  *out_y = radar::kCenterY - static_cast<int>(lroundf(screen_north * px_per_km));
 }
 
 int distSqFromCenter(int x, int y) {

--- a/src/ui/status_screens.cpp
+++ b/src/ui/status_screens.cpp
@@ -11,7 +11,6 @@
 #include "hardware/display.h"
 #include "hardware/display_font.h"
 
-namespace fonts = lgfx::v1::fonts;
 
 namespace {
 


### PR DESCRIPTION
## Configurable Radar Sweep

Adds an optional animated radar sweep to the display. The sweep uses a lightweight single-line overlay that restores the previous line from the cached radar frame, allowing aircraft symbols, labels, runways, and grid graphics to remain unchanged.

The sweep can be enabled or disabled from the Wi-Fi settings portal and is disabled by default. The setting persists across restarts.

### Priority limitation

The ESP32-C3 has a single CPU core, so ADS-B networking and sweep animation compete for processing time:

- **Sweep enabled:** ADS-B fetching runs in a lower-priority background task to keep the animation smooth. Fetching and parsing may take longer under load.
- **Sweep disabled:** The background task is removed, and ADS-B fetching uses the original main-task path. This provides the best reliability and performance at larger ranges, including 25 km, but network requests can briefly block other interface work.

This priority change is intentional and represents a tradeoff between animation smoothness and maximum ADS-B/network performance.